### PR TITLE
소셜 로그인, 일반 로그인 및 jwt 인증 필터 적용

### DIFF
--- a/src/main/java/com/safeking/shop/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/safeking/shop/domain/common/BaseTimeEntity.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners((AuditingEntityListener.class))
+@EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/Member.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/Member.java
@@ -18,7 +18,15 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberAccountType type;
 
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
     public Member(MemberAccountType type) {
         this.type = type;
+        this.status = MemberStatus.TEMP;
+    }
+
+    public void updateActivateMember() {
+        this.status = MemberStatus.ACTIVATE;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/MemberStatus.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/MemberStatus.java
@@ -16,4 +16,8 @@ public enum MemberStatus {
     public String getDescription() {
         return description;
     }
+
+    public boolean isAdditionalAuthRequired() {
+        return this == TEMP;
+    }
 }

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/MemberStatus.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/MemberStatus.java
@@ -1,0 +1,19 @@
+package com.safeking.shop.domain.user.domain.entity;
+
+public enum MemberStatus {
+
+    ACTIVATE("모든 인증과정을 마친 이용 가능한 유저"),
+    TEMP("로그인 정보만을 가진 임시 유저"),
+    WITHDRAWN("탈퇴한 유저"),
+    ;
+
+    private final String description;
+
+    MemberStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/NormalAccount.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/NormalAccount.java
@@ -2,6 +2,7 @@ package com.safeking.shop.domain.user.domain.entity;
 
 import com.safeking.shop.domain.common.BaseTimeEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,20 +16,22 @@ public class NormalAccount extends BaseTimeEntity {
     @Column(name = "normal_account_id")
     private Long id;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     private String loginId;
 
     private String pasword;
 
     private String email;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    public NormalAccount(String loginId, String pasword, String email, Member member) {
+    @Builder
+    public NormalAccount(String loginId, String pasword, String email) {
         this.loginId = loginId;
         this.pasword = pasword;
         this.email = email;
-        this.member = member;
+
+        this.member = new Member(MemberAccountType.NORMAL);
     }
 }

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/NormalAccount.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/NormalAccount.java
@@ -16,7 +16,7 @@ public class NormalAccount extends BaseTimeEntity {
     @Column(name = "normal_account_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/SocialAccount.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/SocialAccount.java
@@ -16,6 +16,10 @@ public class SocialAccount extends BaseTimeEntity {
     @Column(name = "social_account_id")
     private Long id;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
     private Long oauthId;
 
     private String email;
@@ -24,16 +28,18 @@ public class SocialAccount extends BaseTimeEntity {
 
     private OAuthProvider provider;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
     @Builder
-    public SocialAccount(Long oauthId, String email, String name, OAuthProvider provider, Member member) {
+    public SocialAccount(Long oauthId, String email, String name, OAuthProvider provider) {
         this.oauthId = oauthId;
         this.email = email;
         this.name = name;
         this.provider = provider;
-        this.member = member;
+
+        this.member = new Member(MemberAccountType.SOCIAL);
+    }
+
+    public void updateOAuthInfo(String email, String name) {
+        this.email = email;
+        this.name = name;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/user/domain/entity/SocialAccount.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/entity/SocialAccount.java
@@ -20,16 +20,17 @@ public class SocialAccount extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private Long oauthId;
+    private String oauthId;
 
     private String email;
 
     private String name;
 
+    @Enumerated(EnumType.STRING)
     private OAuthProvider provider;
 
     @Builder
-    public SocialAccount(Long oauthId, String email, String name, OAuthProvider provider) {
+    public SocialAccount(String oauthId, String email, String name, OAuthProvider provider) {
         this.oauthId = oauthId;
         this.email = email;
         this.name = name;

--- a/src/main/java/com/safeking/shop/domain/user/domain/repository/NormalAccountRepository.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/repository/NormalAccountRepository.java
@@ -1,0 +1,16 @@
+package com.safeking.shop.domain.user.domain.repository;
+
+import com.safeking.shop.domain.user.domain.entity.NormalAccount;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface NormalAccountRepository extends JpaRepository<NormalAccount, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    @Query("select na from NormalAccount na " +
+            "where na.loginId = :loginId")
+    Optional<NormalAccount> findByLoginIdFetchMember(String loginId);
+}

--- a/src/main/java/com/safeking/shop/domain/user/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/repository/SocialAccountRepository.java
@@ -4,11 +4,14 @@ import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
 import com.safeking.shop.domain.user.domain.entity.SocialAccount;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
     @EntityGraph(attributePaths = {"member"})
-    Optional<SocialAccount> findByOauthIdAndProviderFetchMember(Long oauthId, OAuthProvider provider);
+    @Query("select sa from SocialAccount sa " +
+            "where sa.oauthId = :oauthId and sa.provider = :provider")
+    Optional<SocialAccount> findByOauthIdAndProviderFetchMember(String oauthId, OAuthProvider provider);
 }

--- a/src/main/java/com/safeking/shop/domain/user/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/repository/SocialAccountRepository.java
@@ -1,0 +1,14 @@
+package com.safeking.shop.domain.user.domain.repository;
+
+import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
+import com.safeking.shop.domain.user.domain.entity.SocialAccount;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Optional<SocialAccount> findByOauthIdAndProviderFetchMember(Long oauthId, OAuthProvider provider);
+}

--- a/src/main/java/com/safeking/shop/domain/user/domain/service/NormalAccountService.java
+++ b/src/main/java/com/safeking/shop/domain/user/domain/service/NormalAccountService.java
@@ -1,0 +1,31 @@
+package com.safeking.shop.domain.user.domain.service;
+
+import com.safeking.shop.domain.user.domain.entity.NormalAccount;
+import com.safeking.shop.domain.user.domain.repository.NormalAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NormalAccountService {
+
+    private final NormalAccountRepository normalAccountRepository;
+
+    public Long addNormalAccount(String loginId, String password, String email) {
+        // TODO CustomException
+        normalAccountRepository.findByLoginIdFetchMember(loginId)
+                .ifPresent(normalAccount -> {
+                    throw new RuntimeException();
+                });
+
+        return normalAccountRepository.save(
+                NormalAccount.builder()
+                        .loginId(loginId)
+                        .pasword(password)
+                        .email(email)
+                        .build()
+        ).getId();
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/controller/AuthController.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/controller/AuthController.java
@@ -42,6 +42,12 @@ public class AuthController {
     @PostMapping("/login")
     public LoginResponse login(@RequestBody LoginRequest request,
                                HttpServletResponse response) {
+        /*
+        TODO
+            로그인이 되어 있는 상태에서 또 진행하면 AccessToken이 또 발급됨.
+            RefreshToken은 서버에서 관리하지만 AccessToken은 블랙리스트에 등록하지 않는 이상 관리하지 않음.
+            보안상 문제가 될 수 있다..
+        */
         UserAuthInfo userAuthInfo = normalAccountQueryService.getUserAuthInfoByLoginIdAndPassword(
                 request.getLoginId(),
                 request.getPassword()

--- a/src/main/java/com/safeking/shop/domain/user/web/controller/AuthController.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/controller/AuthController.java
@@ -1,0 +1,68 @@
+package com.safeking.shop.domain.user.web.controller;
+
+import com.safeking.shop.domain.user.domain.service.NormalAccountService;
+import com.safeking.shop.domain.user.web.query.service.NormalAccountQueryService;
+import com.safeking.shop.domain.user.web.query.service.dto.UserAuthInfo;
+import com.safeking.shop.domain.user.web.request.LoginRequest;
+import com.safeking.shop.domain.user.web.request.SignUpRequest;
+import com.safeking.shop.domain.user.web.response.LoginResponse;
+import com.safeking.shop.domain.user.web.response.SignUpResponse;
+import com.safeking.shop.global.jwt.JwtManager;
+import com.safeking.shop.global.jwt.JwtRepository;
+import com.safeking.shop.global.jwt.JwtToken;
+import com.safeking.shop.global.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.time.Instant;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final JwtManager jwtManager;
+    private final JwtRepository jwtRepository;
+    private final NormalAccountService normalAccountService;
+    private final NormalAccountQueryService normalAccountQueryService;
+
+    @PostMapping("/sign-up")
+    public SignUpResponse signUp(@RequestBody SignUpRequest request) {
+        normalAccountService.addNormalAccount(request.getLoginId(), request.getPassword(), request.getEmail());
+        return new SignUpResponse();
+    }
+
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest request,
+                               HttpServletResponse response) {
+        UserAuthInfo userAuthInfo = normalAccountQueryService.getUserAuthInfoByLoginIdAndPassword(
+                request.getLoginId(),
+                request.getPassword()
+        );
+
+        JwtToken accessToken = jwtManager.createAccessToken(userAuthInfo.getUserId(), userAuthInfo.getStatus());
+
+        JwtToken refreshToken = jwtManager.createRefreshToken();
+        Duration refreshTokenExpiryDuration = Duration.between(Instant.now(), refreshToken.getExpiry());
+        jwtRepository.addRefreshToken(
+                userAuthInfo.getUserId(),
+                refreshToken.getToken(),
+                refreshTokenExpiryDuration
+        );
+        CookieUtils.addCookie(
+                response,
+                CookieUtils.COOKIE_NAME_REFRESH_TOKEN,
+                refreshToken.getToken(),
+                (int) refreshTokenExpiryDuration.getSeconds()
+        );
+
+        return new LoginResponse(accessToken.getToken(), userAuthInfo.getStatus().isAdditionalAuthRequired());
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/controller/TestController.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/controller/TestController.java
@@ -1,0 +1,32 @@
+package com.safeking.shop.domain.user.web.controller;
+
+import com.safeking.shop.global.jwt.JwtPrincipal;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/test")
+public class TestController {
+
+    @GetMapping("/temp")
+    public String test1(@AuthenticationPrincipal JwtPrincipal jwtPrincipal) {
+        log.info("{}", jwtPrincipal.toString());
+        return "temp";
+    }
+
+    @GetMapping("/active")
+    public String test2(@AuthenticationPrincipal JwtPrincipal jwtPrincipal) {
+        log.info("{}", jwtPrincipal.toString());
+        return "active";
+    }
+
+    @GetMapping("/admin")
+    public String test3(@AuthenticationPrincipal JwtPrincipal jwtPrincipal) {
+        log.info("{}", jwtPrincipal.toString());
+        return "admin";
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/query/repository/NormalAccountQueryRepository.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/query/repository/NormalAccountQueryRepository.java
@@ -1,0 +1,26 @@
+package com.safeking.shop.domain.user.web.query.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.safeking.shop.domain.user.domain.entity.NormalAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.safeking.shop.domain.user.domain.entity.QNormalAccount.normalAccount;
+
+@Repository
+@RequiredArgsConstructor
+public class NormalAccountQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<NormalAccount> findByLoginIdFetchMember(String loginId) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(normalAccount)
+                        .leftJoin(normalAccount.member).fetchJoin()
+                        .where(normalAccount.loginId.eq(loginId))
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/query/service/NormalAccountQueryService.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/query/service/NormalAccountQueryService.java
@@ -1,0 +1,34 @@
+package com.safeking.shop.domain.user.web.query.service;
+
+import com.safeking.shop.domain.user.domain.entity.Member;
+import com.safeking.shop.domain.user.domain.entity.NormalAccount;
+import com.safeking.shop.domain.user.web.query.repository.NormalAccountQueryRepository;
+import com.safeking.shop.domain.user.web.query.service.dto.UserAuthInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NormalAccountQueryService {
+
+    private final NormalAccountQueryRepository normalAccountQueryRepository;
+
+    public UserAuthInfo getUserAuthInfoByLoginIdAndPassword(String loginId, String password) {
+        // TODO CustomException
+        NormalAccount normalAccount = normalAccountQueryRepository.findByLoginIdFetchMember(loginId)
+                .orElseThrow();
+        checkPassword(password, normalAccount);
+
+        Member member = normalAccount.getMember();
+        return new UserAuthInfo(member.getId(), member.getStatus());
+    }
+
+    private void checkPassword(String password, NormalAccount normalAccount) {
+        if (!normalAccount.getPasword().equals(password)) {
+            // TODO CustomException
+            throw new RuntimeException();
+        }
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/query/service/dto/UserAuthInfo.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/query/service/dto/UserAuthInfo.java
@@ -1,0 +1,13 @@
+package com.safeking.shop.domain.user.web.query.service.dto;
+
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserAuthInfo {
+
+    private Long userId;
+    private MemberStatus status;
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/request/LoginRequest.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.safeking.shop.domain.user.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequest {
+
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/request/SignUpRequest.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/request/SignUpRequest.java
@@ -1,0 +1,13 @@
+package com.safeking.shop.domain.user.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignUpRequest {
+
+    private String loginId;
+    private String password;
+    private String email;
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/response/LoginResponse.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/response/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.safeking.shop.domain.user.web.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String token;
+    private boolean additionalAuthRequired;
+}

--- a/src/main/java/com/safeking/shop/domain/user/web/response/SignUpResponse.java
+++ b/src/main/java/com/safeking/shop/domain/user/web/response/SignUpResponse.java
@@ -1,0 +1,20 @@
+package com.safeking.shop.domain.user.web.response;
+
+public class SignUpResponse {
+
+    private static final String SUCCESS_MESSAGE = "회원 가입이 성공적으로 완료되었습니다.";
+
+    private String message;
+
+    public SignUpResponse() {
+        this.message = SUCCESS_MESSAGE;
+    }
+
+    public SignUpResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/config/RedisConfig.java
+++ b/src/main/java/com/safeking/shop/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.safeking.shop.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
+++ b/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.safeking.shop.global.config;
 
 import com.safeking.shop.global.security.oauth2.repository.OAuth2AuthorizationRequestRepository;
+import com.safeking.shop.global.security.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
 
     @Bean
@@ -38,11 +40,11 @@ public class SecurityConfig {
 
                 .and()
                 .redirectionEndpoint()
-                .baseUri("/oauth2/callback/*");
+                .baseUri("/oauth2/callback/*")
 
-//                .and()
-//                .userInfoEndpoint()
-//                .userService()
+                .and()
+                .userInfoEndpoint()
+                .userService(customOAuth2UserService);
 //
 //                .and()
 //                .successHandler()

--- a/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
+++ b/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.safeking.shop.global.config;
 
+import com.safeking.shop.global.jwt.JwtManager;
+import com.safeking.shop.global.jwt.JwtRepository;
+import com.safeking.shop.global.security.filter.JwtAuthenticationFilter;
 import com.safeking.shop.global.security.oauth2.handler.CustomOAuth2AuthenticationFailureHandler;
 import com.safeking.shop.global.security.oauth2.handler.CustomOAuth2AuthenticationSuccessHandler;
 import com.safeking.shop.global.security.oauth2.repository.OAuth2AuthorizationRequestRepository;
 import com.safeking.shop.global.security.oauth2.service.CustomOAuth2UserService;
+import com.safeking.shop.global.security.role.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,15 +15,22 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtManager jwtManager;
+    private final JwtRepository jwtRepository;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
     private final CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler;
     private final CustomOAuth2AuthenticationFailureHandler customOAuth2AuthenticationFailureHandler;
+
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtManager, jwtRepository);
+    }
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -52,7 +63,17 @@ public class SecurityConfig {
 
                 .and()
                 .successHandler(customOAuth2AuthenticationSuccessHandler)
-                .failureHandler(customOAuth2AuthenticationFailureHandler);
+                .failureHandler(customOAuth2AuthenticationFailureHandler)
+
+                .and()
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .authorizeRequests()
+                .antMatchers("/api/v1/auth/**").permitAll()
+                .antMatchers("/api/v1/test/temp").hasRole(Role.TEMP.name())
+                .antMatchers("/api/v1/test/active").hasRole(Role.USER.name())
+                .antMatchers("/api/v1/test/admin").hasRole(Role.ADMIN.name());
 
         return http.build();
     }

--- a/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
+++ b/src/main/java/com/safeking/shop/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.safeking.shop.global.config;
 
+import com.safeking.shop.global.security.oauth2.handler.CustomOAuth2AuthenticationFailureHandler;
+import com.safeking.shop.global.security.oauth2.handler.CustomOAuth2AuthenticationSuccessHandler;
 import com.safeking.shop.global.security.oauth2.repository.OAuth2AuthorizationRequestRepository;
 import com.safeking.shop.global.security.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,8 @@ public class SecurityConfig {
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
+    private final CustomOAuth2AuthenticationSuccessHandler customOAuth2AuthenticationSuccessHandler;
+    private final CustomOAuth2AuthenticationFailureHandler customOAuth2AuthenticationFailureHandler;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -44,11 +48,11 @@ public class SecurityConfig {
 
                 .and()
                 .userInfoEndpoint()
-                .userService(customOAuth2UserService);
-//
-//                .and()
-//                .successHandler()
-//                .failureHandler()
+                .userService(customOAuth2UserService)
+
+                .and()
+                .successHandler(customOAuth2AuthenticationSuccessHandler)
+                .failureHandler(customOAuth2AuthenticationFailureHandler);
 
         return http.build();
     }

--- a/src/main/java/com/safeking/shop/global/jwt/JwtClaims.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtClaims.java
@@ -1,0 +1,68 @@
+package com.safeking.shop.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class JwtClaims {
+
+    private static final String CLAIM_NAME_USER_ID = "uid";
+    private static final String CLAIM_NAME_AUTHORIZATION = "auth";
+    private static final String CLAIM_NAME_ISSUED_AT = Claims.ISSUED_AT;
+    private static final String CLAIM_NAME_EXPIRATION = Claims.EXPIRATION;
+
+    private Long userId;
+    private String auth;
+    private Instant issuedAt;
+    private Instant expiry;
+
+    public JwtClaims(Map<String, Object> payloadMap) {
+        Object uidObj = payloadMap.get(CLAIM_NAME_USER_ID);
+        if (uidObj != null) {
+            this.userId = Long.parseLong(uidObj.toString());
+        }
+
+        Object authObj = payloadMap.get(CLAIM_NAME_AUTHORIZATION);
+        if (authObj != null) {
+            this.auth = authObj.toString();
+        }
+
+        Object iatObj = payloadMap.get(CLAIM_NAME_ISSUED_AT);
+        if (iatObj != null) {
+            this.issuedAt = toInstant(iatObj);
+        }
+
+        Object expObj = payloadMap.get(CLAIM_NAME_EXPIRATION);
+        if (expObj != null) {
+            this.expiry = toInstant(expObj);
+        }
+    }
+
+    @Builder
+    public JwtClaims(Long userId, String auth, Instant issuedAt, Instant expiry) {
+        this.userId = userId;
+        this.auth = auth;
+        this.issuedAt = issuedAt;
+        this.expiry = expiry;
+    }
+
+    private Instant toInstant(Object obj) {
+        return Instant.ofEpochMilli(Long.parseLong(obj.toString()) * 1000);
+    }
+
+    public Map<String, Object> getClaimsMap() {
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put(CLAIM_NAME_USER_ID, userId);
+        claims.put(CLAIM_NAME_AUTHORIZATION, auth);
+        claims.put(CLAIM_NAME_ISSUED_AT, Date.from(issuedAt));
+        claims.put(CLAIM_NAME_EXPIRATION, Date.from(expiry));
+
+        return claims;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
@@ -1,7 +1,9 @@
 package com.safeking.shop.global.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
 import com.safeking.shop.global.security.role.Role;
+import com.safeking.shop.global.security.role.RoleFactory;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -50,7 +52,8 @@ public class JwtManager {
         return new JwtToken(accessTokenValue, expiry);
     }
 
-    public JwtToken createAccessToken(Long userId, Role role) {
+    public JwtToken createAccessToken(Long userId, MemberStatus status) {
+        Role role = RoleFactory.getRoleByMemberStatus(status);
         return createAccessToken(userId, role.getRoleValue());
     }
 

--- a/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
@@ -1,18 +1,20 @@
 package com.safeking.shop.global.jwt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.safeking.shop.domain.user.domain.entity.MemberStatus;
 import com.safeking.shop.global.security.role.Role;
 import com.safeking.shop.global.security.role.RoleFactory;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
-import java.sql.Date;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
 
 @Component
 public class JwtManager {
@@ -37,16 +39,48 @@ public class JwtManager {
         this.reissueRefreshTokenCriteriaSec = reissueRefreshTokenCriteriaSec;
     }
 
+    public boolean validationToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims != null;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    public JwtClaims getJwtClaims(String token) {
+        String[] split = token.split("\\.");
+        String jwtPayload = split[1];
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        String payload = new String(decoder.decode(jwtPayload));
+        Map<String, Object> payloadMap;
+        try {
+            payloadMap = objectMapper.readValue(payload, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            // TODO 예외 처리
+            throw new RuntimeException(e);
+        }
+        return new JwtClaims(payloadMap);
+    }
+
     public JwtToken createAccessToken(Long userId, String authorities) {
         Instant now = Instant.now();
         Instant expiry = now.plusSeconds(accessTokenExpirySec);
+        JwtClaims jwtClaims = JwtClaims.builder()
+                .userId(userId)
+                .auth(authorities)
+                .issuedAt(now)
+                .expiry(expiry)
+                .build();
 
         String accessTokenValue = Jwts.builder()
                 .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                .claim("auth", authorities)
-                .claim("uid", userId)
-                .setIssuedAt(Date.from(now))
-                .setExpiration(Date.from(expiry))
+                .setClaims(jwtClaims.getClaimsMap())
                 .compact();
 
         return new JwtToken(accessTokenValue, expiry);
@@ -60,10 +94,13 @@ public class JwtManager {
     public JwtToken createRefreshToken() {
         Instant now = Instant.now();
         Instant expiry = now.plusSeconds(refreshTokenExpirySec);
+        JwtClaims jwtClaims = JwtClaims.builder()
+                .issuedAt(now)
+                .expiry(expiry)
+                .build();
         String refreshTokenValue = Jwts.builder()
                 .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
-                .setIssuedAt(Date.from(now))
-                .setExpiration(Date.from(expiry))
+                .setClaims(jwtClaims.getClaimsMap())
                 .compact();
 
         return new JwtToken(refreshTokenValue, expiry);

--- a/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtManager.java
@@ -1,0 +1,68 @@
+package com.safeking.shop.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.safeking.shop.global.security.role.Role;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.Instant;
+
+@Component
+public class JwtManager {
+
+    private final ObjectMapper objectMapper;
+
+    private final String jwtSecretKey;
+    private final long accessTokenExpirySec;
+    private final long refreshTokenExpirySec;
+    private final long reissueRefreshTokenCriteriaSec;
+
+    public JwtManager(ObjectMapper objectMapper,
+                      @Value("${jwt.secret}") String jwtSecretKey,
+                      @Value("${jwt.access-token.expire-time}") long accessTokenExpirySec,
+                      @Value("${jwt.refresh-token.expire-time}") long refreshTokenExpirySec,
+                      @Value("${jwt.refresh-token.reissue-criteria}") long reissueRefreshTokenCriteriaSec) {
+        this.objectMapper = objectMapper;
+
+        this.jwtSecretKey = jwtSecretKey;
+        this.accessTokenExpirySec = accessTokenExpirySec;
+        this.refreshTokenExpirySec = refreshTokenExpirySec;
+        this.reissueRefreshTokenCriteriaSec = reissueRefreshTokenCriteriaSec;
+    }
+
+    public JwtToken createAccessToken(Long userId, String authorities) {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(accessTokenExpirySec);
+
+        String accessTokenValue = Jwts.builder()
+                .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                .claim("auth", authorities)
+                .claim("uid", userId)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiry))
+                .compact();
+
+        return new JwtToken(accessTokenValue, expiry);
+    }
+
+    public JwtToken createAccessToken(Long userId, Role role) {
+        return createAccessToken(userId, role.getRoleValue());
+    }
+
+    public JwtToken createRefreshToken() {
+        Instant now = Instant.now();
+        Instant expiry = now.plusSeconds(refreshTokenExpirySec);
+        String refreshTokenValue = Jwts.builder()
+                .signWith(Keys.hmacShaKeyFor(jwtSecretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS512)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiry))
+                .compact();
+
+        return new JwtToken(refreshTokenValue, expiry);
+    }
+}

--- a/src/main/java/com/safeking/shop/global/jwt/JwtPrincipal.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtPrincipal.java
@@ -1,0 +1,15 @@
+package com.safeking.shop.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor
+public class JwtPrincipal {
+
+    private String accessToken;
+    private Instant expiry;
+    private Long userId;
+}

--- a/src/main/java/com/safeking/shop/global/jwt/JwtRepository.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtRepository.java
@@ -1,0 +1,38 @@
+package com.safeking.shop.global.jwt;
+
+import com.safeking.shop.global.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRepository {
+
+    private static final String BLACKLIST_PREFIX = "BLACKLIST_";
+    private static final String UID_PREFIX = "UID_";
+
+    private final RedisRepository redisRepository;
+
+    public void addBlackList(String accessToken, Duration duration) {
+        redisRepository.set(BLACKLIST_PREFIX + accessToken, accessToken, duration);
+    }
+
+    public void addRefreshToken(Long userId, String refreshToken, Duration duration) {
+        redisRepository.set(UID_PREFIX + userId, refreshToken, duration);
+    }
+
+    public Optional<String> findBlackListTokenByToken(String accessToken) {
+        return Optional.ofNullable(redisRepository.get(BLACKLIST_PREFIX + accessToken));
+    }
+
+    public Optional<String> findRefreshTokenByUserId(String userId) {
+        return Optional.ofNullable(redisRepository.get(UID_PREFIX + userId));
+    }
+
+    public void removeRefreshToken(String userId) {
+        redisRepository.remove(UID_PREFIX + userId);
+    }
+}

--- a/src/main/java/com/safeking/shop/global/jwt/JwtToken.java
+++ b/src/main/java/com/safeking/shop/global/jwt/JwtToken.java
@@ -1,0 +1,14 @@
+package com.safeking.shop.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor
+public class JwtToken {
+
+    private String token;
+    private Instant expiry;
+}

--- a/src/main/java/com/safeking/shop/global/redis/RedisRepository.java
+++ b/src/main/java/com/safeking/shop/global/redis/RedisRepository.java
@@ -1,0 +1,29 @@
+package com.safeking.shop.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void set(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String get(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void remove(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/safeking/shop/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.safeking.shop.global.security.filter;
+
+import com.safeking.shop.global.jwt.JwtClaims;
+import com.safeking.shop.global.jwt.JwtManager;
+import com.safeking.shop.global.jwt.JwtPrincipal;
+import com.safeking.shop.global.jwt.JwtRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtManager jwtManager;
+    private final JwtRepository jwtRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // TODO Access token 만료시 만료 응답 필요
+        String accessToken = resolveAccessToken(request);
+        if (isValidAccessToken(accessToken)) {
+            JwtClaims jwtClaims = jwtManager.getJwtClaims(accessToken);
+
+            JwtPrincipal jwtPrincipal = new JwtPrincipal(accessToken, jwtClaims.getExpiry(), jwtClaims.getUserId());
+            List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(jwtClaims.getAuth()));
+            Authentication authentication = new UsernamePasswordAuthenticationToken(jwtPrincipal, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isValidAccessToken(String accessToken) {
+        return accessToken != null
+                && jwtManager.validationToken(accessToken)
+                && jwtRepository.findBlackListTokenByToken(accessToken).isEmpty();
+    }
+
+    private String resolveAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
+            return authorizationHeader.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/handler/CustomOAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/handler/CustomOAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,43 @@
+package com.safeking.shop.global.security.oauth2.handler;
+
+import com.safeking.shop.global.security.oauth2.repository.OAuth2AuthorizationRequestRepository;
+import com.safeking.shop.global.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private final OAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        String redirectUri = CookieUtils.getCookie(request, CookieUtils.COOKIE_NAME_REDIRECT_URI)
+                .map(Cookie::getValue)
+                .orElseThrow(); // TODO CustomException
+
+        log.error("oauth2 login fail.", exception);
+
+        String targetUri = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        oAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        response.sendRedirect(targetUri);
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/handler/CustomOAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/handler/CustomOAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,72 @@
+package com.safeking.shop.global.security.oauth2.handler;
+
+import com.safeking.shop.global.jwt.JwtManager;
+import com.safeking.shop.global.jwt.JwtRepository;
+import com.safeking.shop.global.jwt.JwtToken;
+import com.safeking.shop.global.security.oauth2.repository.OAuth2AuthorizationRequestRepository;
+import com.safeking.shop.global.security.oauth2.service.UserIdOAuth2User;
+import com.safeking.shop.global.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtManager jwtManager;
+    private final JwtRepository jwtRepository;
+    private final OAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        UserIdOAuth2User userIdOAuth2User = (UserIdOAuth2User) authentication.getPrincipal();
+
+        String authorities = userIdOAuth2User.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        JwtToken accessToken = jwtManager.createAccessToken(userIdOAuth2User.getUserId(), authorities);
+        JwtToken refreshToken = jwtManager.createRefreshToken();
+        jwtRepository.addRefreshToken(
+                userIdOAuth2User.getUserId(),
+                refreshToken.getToken(),
+                Duration.between(Instant.now(), refreshToken.getExpiry())
+        );
+
+        CookieUtils.addCookie(
+                response,
+                CookieUtils.COOKIE_NAME_REFRESH_TOKEN,
+                refreshToken.getToken(),
+                (int) Duration.between(Instant.now(), refreshToken.getExpiry()).getSeconds()
+        );
+
+        String redirectUri = CookieUtils.getCookie(request, CookieUtils.COOKIE_NAME_REDIRECT_URI)
+                .map(Cookie::getValue)
+                .orElseThrow(); // TODO CustomException
+
+        String targetUri = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("token", accessToken.getToken())
+                .queryParam("additional-auth-required", userIdOAuth2User.requiredAdditionalAuth())
+                .build().toUriString();
+
+        oAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+        response.sendRedirect(targetUri);
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/repository/OAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/repository/OAuth2AuthorizationRequestRepository.java
@@ -28,6 +28,7 @@ public class OAuth2AuthorizationRequestRepository implements AuthorizationReques
         // OAuth2 로그인 요청 정보
         CookieUtils.addCookie(response, CookieUtils.COOKIE_NAME_OAUTH2_AUTHORIZATION_REQUEST, CookieUtils.serialize(authorizationRequest), cookieAge);
         // OAuth2 로그인 성공시 redirect 할 uri
+        // TODO redirect_uri 없을시 Error
         CookieUtils.addCookie(response, CookieUtils.COOKIE_NAME_REDIRECT_URI, request.getParameter("redirect_uri"), cookieAge);
     }
 

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,30 @@
+//package com.safeking.shop.global.security.oauth2.service;
+//
+//import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfoFactory;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.oauth2.client.registration.ClientRegistration;
+//import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+//import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+//import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+//import org.springframework.security.oauth2.core.user.OAuth2User;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.Map;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+//
+//    @Override
+//    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+//        OAuth2User oAuth2User = super.loadUser(userRequest);
+//
+//        ClientRegistration clientRegistration = userRequest.getClientRegistration();
+//        String registrationId = clientRegistration.getRegistrationId();
+//        String userNameAttributeName = clientRegistration.getProviderDetails()
+//                .getUserInfoEndpoint()
+//                .getUserNameAttributeName();
+//        Map<String, Object> userAttributes = oAuth2User.getAttributes();
+//        OAuth2UserInfoFactory.getOAuthUserInfo(userAttributes)
+//    }
+//}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -32,8 +32,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .getUserInfoEndpoint()
                 .getUserNameAttributeName();
         Map<String, Object> userAttributes = oAuth2User.getAttributes();
-        OAuth2UserInfo oAuthUserInfo = OAuth2UserInfoFactory.getOAuthUserInfo(registrationId, userAttributes);
 
+        OAuth2UserInfo oAuthUserInfo = OAuth2UserInfoFactory.getOAuthUserInfo(registrationId, userAttributes);
         MemberAuthenticationInfo memberAuthenticationInfo = oAuth2UserAccountService.saveOrUpdateSocialAccount(oAuthUserInfo);
 
         return new UserIdOAuth2User(

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,7 +1,5 @@
 package com.safeking.shop.global.security.oauth2.service;
 
-import com.safeking.shop.domain.user.domain.entity.MemberStatus;
-import com.safeking.shop.global.security.role.Role;
 import com.safeking.shop.global.security.oauth2.service.domain.MemberAuthenticationInfo;
 import com.safeking.shop.global.security.oauth2.service.domain.OAuth2UserAccountService;
 import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfo;
@@ -38,9 +36,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         return new UserIdOAuth2User(
                 memberAuthenticationInfo.getMemberId(),
-                memberAuthenticationInfo.getStatus() == MemberStatus.ACTIVATE
-                        ? Role.ACTIVE_USER
-                        : Role.TEMP_USER,
+                memberAuthenticationInfo.getStatus(),
                 userAttributes,
                 userNameAttributeName
         );

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,30 +1,48 @@
-//package com.safeking.shop.global.security.oauth2.service;
-//
-//import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfoFactory;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.oauth2.client.registration.ClientRegistration;
-//import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-//import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-//import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-//import org.springframework.security.oauth2.core.user.OAuth2User;
-//import org.springframework.stereotype.Service;
-//
-//import java.util.Map;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-//
-//    @Override
-//    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-//        OAuth2User oAuth2User = super.loadUser(userRequest);
-//
-//        ClientRegistration clientRegistration = userRequest.getClientRegistration();
-//        String registrationId = clientRegistration.getRegistrationId();
-//        String userNameAttributeName = clientRegistration.getProviderDetails()
-//                .getUserInfoEndpoint()
-//                .getUserNameAttributeName();
-//        Map<String, Object> userAttributes = oAuth2User.getAttributes();
-//        OAuth2UserInfoFactory.getOAuthUserInfo(userAttributes)
-//    }
-//}
+package com.safeking.shop.global.security.oauth2.service;
+
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
+import com.safeking.shop.global.security.role.Role;
+import com.safeking.shop.global.security.oauth2.service.domain.MemberAuthenticationInfo;
+import com.safeking.shop.global.security.oauth2.service.domain.OAuth2UserAccountService;
+import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfo;
+import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfoFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final OAuth2UserAccountService oAuth2UserAccountService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        ClientRegistration clientRegistration = userRequest.getClientRegistration();
+        String registrationId = clientRegistration.getRegistrationId();
+        String userNameAttributeName = clientRegistration.getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        Map<String, Object> userAttributes = oAuth2User.getAttributes();
+        OAuth2UserInfo oAuthUserInfo = OAuth2UserInfoFactory.getOAuthUserInfo(registrationId, userAttributes);
+
+        MemberAuthenticationInfo memberAuthenticationInfo = oAuth2UserAccountService.saveOrUpdateSocialAccount(oAuthUserInfo);
+
+        return new UserIdOAuth2User(
+                memberAuthenticationInfo.getMemberId(),
+                memberAuthenticationInfo.getStatus() == MemberStatus.ACTIVATE
+                        ? Role.ACTIVE_USER
+                        : Role.TEMP_USER,
+                userAttributes,
+                userNameAttributeName
+        );
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/UserIdOAuth2User.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/UserIdOAuth2User.java
@@ -1,0 +1,34 @@
+package com.safeking.shop.global.security.oauth2.service;
+
+import com.safeking.shop.global.security.role.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class UserIdOAuth2User extends DefaultOAuth2User {
+
+    private Long userId;
+
+    public UserIdOAuth2User(Long userId, Role role,
+                            Map<String, Object> attributes,
+                            String nameAttributeKey) {
+        super(Collections.singletonList(new SimpleGrantedAuthority(role.getRoleValue())),
+                attributes,
+                nameAttributeKey);
+        this.userId = userId;
+    }
+
+    public boolean requiredAdditionalAuth() {
+        // 권한이 TEMP_USER 이면 true
+        return this.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .noneMatch(s -> s.equals(Role.TEMP_USER.getRoleValue()));
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/UserIdOAuth2User.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/UserIdOAuth2User.java
@@ -1,7 +1,8 @@
 package com.safeking.shop.global.security.oauth2.service;
 
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
 import com.safeking.shop.global.security.role.Role;
-import org.springframework.security.core.GrantedAuthority;
+import com.safeking.shop.global.security.role.RoleFactory;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
@@ -11,24 +12,23 @@ import java.util.Map;
 public class UserIdOAuth2User extends DefaultOAuth2User {
 
     private Long userId;
+    private MemberStatus status;
 
-    public UserIdOAuth2User(Long userId, Role role,
+    public UserIdOAuth2User(Long userId, MemberStatus status,
                             Map<String, Object> attributes,
                             String nameAttributeKey) {
-        super(Collections.singletonList(new SimpleGrantedAuthority(role.getRoleValue())),
+        super(Collections.singletonList(new SimpleGrantedAuthority(RoleFactory.getRoleByMemberStatus(status).getRoleValue())),
                 attributes,
                 nameAttributeKey);
         this.userId = userId;
-    }
-
-    public boolean requiredAdditionalAuth() {
-        // 권한이 TEMP_USER 이면 true
-        return this.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .noneMatch(s -> s.equals(Role.TEMP_USER.getRoleValue()));
+        this.status = status;
     }
 
     public Long getUserId() {
         return userId;
+    }
+
+    public MemberStatus getStatus() {
+        return status;
     }
 }

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/domain/MemberAuthenticationInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/domain/MemberAuthenticationInfo.java
@@ -1,0 +1,16 @@
+package com.safeking.shop.global.security.oauth2.service.domain;
+
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
+import lombok.Getter;
+
+@Getter
+public class MemberAuthenticationInfo {
+
+    private Long memberId;
+    private MemberStatus status;
+
+    public MemberAuthenticationInfo(Long memberId, MemberStatus status) {
+        this.memberId = memberId;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/service/domain/OAuth2UserAccountService.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/service/domain/OAuth2UserAccountService.java
@@ -1,0 +1,44 @@
+package com.safeking.shop.global.security.oauth2.service.domain;
+
+import com.safeking.shop.domain.user.domain.entity.Member;
+import com.safeking.shop.domain.user.domain.entity.SocialAccount;
+import com.safeking.shop.domain.user.domain.repository.SocialAccountRepository;
+import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OAuth2UserAccountService {
+
+    private final SocialAccountRepository socialAccountRepository;
+
+    public MemberAuthenticationInfo saveOrUpdateSocialAccount(OAuth2UserInfo oAuth2UserInfo) {
+        Optional<SocialAccount> optionalSocialAccount = socialAccountRepository.findByOauthIdAndProviderFetchMember(
+                oAuth2UserInfo.getOAuthId(),
+                oAuth2UserInfo.getProvider()
+        );
+
+        SocialAccount socialAccount;
+        if (optionalSocialAccount.isPresent()) {
+            socialAccount = optionalSocialAccount.get();
+            socialAccount.updateOAuthInfo(oAuth2UserInfo.getEmail(), oAuth2UserInfo.getName());
+        } else {
+            socialAccount = socialAccountRepository.save(
+                    SocialAccount.builder()
+                            .oauthId(oAuth2UserInfo.getOAuthId())
+                            .provider(oAuth2UserInfo.getProvider())
+                            .email(oAuth2UserInfo.getEmail())
+                            .name(oAuth2UserInfo.getName())
+                            .build()
+            );
+        }
+
+        Member member = socialAccount.getMember();
+        return new MemberAuthenticationInfo(member.getId(), member.getStatus());
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,27 @@
+package com.safeking.shop.global.security.oauth2.user;
+
+import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+
+    // Provider 에게서 제공받은 유저 정보를 담는 필드
+    protected Map<String, Object> userAttributes;
+
+    public OAuth2UserInfo(Map<String, Object> userAttributes) {
+        this.userAttributes = userAttributes;
+    }
+
+    public Map<String, Object> getUserAttributes() {
+        return userAttributes;
+    }
+
+    public abstract Long getOAuthId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract OAuthProvider getProvider();
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfo.java
@@ -17,7 +17,7 @@ public abstract class OAuth2UserInfo {
         return userAttributes;
     }
 
-    public abstract Long getOAuthId();
+    public abstract String getOAuthId();
 
     public abstract String getName();
 

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,21 @@
+package com.safeking.shop.global.security.oauth2.user;
+
+import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
+import com.safeking.shop.global.security.oauth2.user.impl.GoogleUserInfo;
+import com.safeking.shop.global.security.oauth2.user.impl.KakaoUserInfo;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuthUserInfo(String providerName, Map<String, Object> userAttributes) {
+        switch (OAuthProvider.from(providerName)) {
+            case GOOGLE:
+                return new GoogleUserInfo(userAttributes);
+            case KAKAO:
+                return new KakaoUserInfo(userAttributes);
+            default:
+                throw new IllegalArgumentException("지원하지 않는 Provider 입니다.");
+        }
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/GoogleUserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/GoogleUserInfo.java
@@ -5,30 +5,31 @@ import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
 
 import java.util.Map;
 
-// TODO 데이터 확인 후 구현
 public class GoogleUserInfo extends OAuth2UserInfo {
+
+    private static final OAuthProvider PROVIDER = OAuthProvider.GOOGLE;
 
     public GoogleUserInfo(Map<String, Object> userAttributes) {
         super(userAttributes);
     }
 
     @Override
-    public Long getOAuthId() {
-        return null;
+    public String getOAuthId() {
+        return this.userAttributes.get("sub").toString();
     }
 
     @Override
     public String getName() {
-        return null;
+        return this.userAttributes.get("name").toString();
     }
 
     @Override
     public String getEmail() {
-        return null;
+        return this.userAttributes.get("email").toString();
     }
 
     @Override
     public OAuthProvider getProvider() {
-        return null;
+        return PROVIDER;
     }
 }

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/GoogleUserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/GoogleUserInfo.java
@@ -1,0 +1,34 @@
+package com.safeking.shop.global.security.oauth2.user.impl;
+
+import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfo;
+import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
+
+import java.util.Map;
+
+// TODO 데이터 확인 후 구현
+public class GoogleUserInfo extends OAuth2UserInfo {
+
+    public GoogleUserInfo(Map<String, Object> userAttributes) {
+        super(userAttributes);
+    }
+
+    @Override
+    public Long getOAuthId() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getEmail() {
+        return null;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return null;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/KakaoUserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/KakaoUserInfo.java
@@ -5,30 +5,39 @@ import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
 
 import java.util.Map;
 
-// TODO 데이터 확인 후 구현
 public class KakaoUserInfo extends OAuth2UserInfo {
+
+    private static final OAuthProvider PROVIDER = OAuthProvider.KAKAO;
 
     public KakaoUserInfo(Map<String, Object> userAttributes) {
         super(userAttributes);
     }
 
     @Override
-    public Long getOAuthId() {
-        return null;
+    public String getOAuthId() {
+        return this.userAttributes.get("id").toString();
     }
 
     @Override
     public String getName() {
-        return null;
+        Map<String, Object> properties = (Map<String, Object>) this.userAttributes.get("properties");
+        if (properties == null) {
+            return null;
+        }
+        return (String) properties.get("nickname");
     }
 
     @Override
     public String getEmail() {
-        return null;
+        Map<String, Object> kakaoAccount = (Map<String, Object>) this.userAttributes.get("kakao_account");
+        if (kakaoAccount == null) {
+            return null;
+        }
+        return  (String) kakaoAccount.get("email");
     }
 
     @Override
     public OAuthProvider getProvider() {
-        return null;
+        return PROVIDER;
     }
 }

--- a/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/KakaoUserInfo.java
+++ b/src/main/java/com/safeking/shop/global/security/oauth2/user/impl/KakaoUserInfo.java
@@ -1,0 +1,34 @@
+package com.safeking.shop.global.security.oauth2.user.impl;
+
+import com.safeking.shop.global.security.oauth2.user.OAuth2UserInfo;
+import com.safeking.shop.domain.user.domain.entity.OAuthProvider;
+
+import java.util.Map;
+
+// TODO 데이터 확인 후 구현
+public class KakaoUserInfo extends OAuth2UserInfo {
+
+    public KakaoUserInfo(Map<String, Object> userAttributes) {
+        super(userAttributes);
+    }
+
+    @Override
+    public Long getOAuthId() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getEmail() {
+        return null;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return null;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/role/Role.java
+++ b/src/main/java/com/safeking/shop/global/security/role/Role.java
@@ -1,5 +1,7 @@
 package com.safeking.shop.global.security.role;
 
+import java.util.stream.Stream;
+
 public enum Role {
 
     ACTIVE_USER("ROLE_USER", "모든 유저 기능 이용 가능한 유저 권한"),
@@ -21,5 +23,12 @@ public enum Role {
 
     public String getDescription() {
         return description;
+    }
+
+    public static Role roleValueToRole(String roleValue) {
+        return Stream.of(values())
+                .filter(role -> role.getRoleValue().equals(roleValue))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/safeking/shop/global/security/role/Role.java
+++ b/src/main/java/com/safeking/shop/global/security/role/Role.java
@@ -4,8 +4,8 @@ import java.util.stream.Stream;
 
 public enum Role {
 
-    ACTIVE_USER("ROLE_USER", "모든 유저 기능 이용 가능한 유저 권한"),
-    TEMP_USER("ROLE_TEMP", "인증 정보 입력만 가능한 임시 유저 권한"),
+    USER("ROLE_USER", "모든 유저 기능 이용 가능한 유저 권한"),
+    TEMP("ROLE_TEMP", "인증 정보 입력만 가능한 임시 유저 권한"),
     ADMIN("ROLE_ADMIN", "관리자 권한"),
     ;
 

--- a/src/main/java/com/safeking/shop/global/security/role/Role.java
+++ b/src/main/java/com/safeking/shop/global/security/role/Role.java
@@ -1,0 +1,25 @@
+package com.safeking.shop.global.security.role;
+
+public enum Role {
+
+    ACTIVE_USER("ROLE_USER", "모든 유저 기능 이용 가능한 유저 권한"),
+    TEMP_USER("ROLE_TEMP", "인증 정보 입력만 가능한 임시 유저 권한"),
+    ADMIN("ROLE_ADMIN", "관리자 권한"),
+    ;
+
+    private final String roleValue;
+    private final String description;
+
+    Role(String value, String description) {
+        this.roleValue = value;
+        this.description = description;
+    }
+
+    public String getRoleValue() {
+        return roleValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/role/RoleFactory.java
+++ b/src/main/java/com/safeking/shop/global/security/role/RoleFactory.java
@@ -1,0 +1,17 @@
+package com.safeking.shop.global.security.role;
+
+import com.safeking.shop.domain.user.domain.entity.MemberStatus;
+
+public class RoleFactory {
+
+    public static Role getRoleByMemberStatus(MemberStatus status) {
+        switch (status) {
+            case TEMP:
+                return Role.TEMP_USER;
+            case ACTIVATE:
+                return Role.ACTIVE_USER;
+            default:
+                throw new IllegalArgumentException("유효하지 않은 회원의 상태입니다.");
+        }
+    }
+}

--- a/src/main/java/com/safeking/shop/global/security/role/RoleFactory.java
+++ b/src/main/java/com/safeking/shop/global/security/role/RoleFactory.java
@@ -7,9 +7,9 @@ public class RoleFactory {
     public static Role getRoleByMemberStatus(MemberStatus status) {
         switch (status) {
             case TEMP:
-                return Role.TEMP_USER;
+                return Role.TEMP;
             case ACTIVATE:
-                return Role.ACTIVE_USER;
+                return Role.USER;
             default:
                 throw new IllegalArgumentException("유효하지 않은 회원의 상태입니다.");
         }


### PR DESCRIPTION
### 소셜 로그인 기능 구현
카카오, 구글 소셜 로그인 기능을 구현했습니다.
소셜 로그인 서비스 제공 벤더마다 유저 정보를 내려주는 형식이 달라서 `OAuth2UserInfo` 추상 클래스를 만들고, 이를 구현하여 카카오, 구글의 유저 정보를 공통적으로 사용할 수 있도록 했습니다. 추상 클래스의 구현체는 `OAuth2UserInfoFactory`의 팩토리 메서드를 통해 생성됩니다.

소셜 로그인에 성공하면 `CustomOAuth2AuthenticationSuccessHandler` 클래스에서 유저 정보를 기반으로 토큰을 생성하고 응답으로 반환합니다.

추가로 소셜 로그인 성공시, 유저의 본인인증 정보가 있는지 확인하여 로그인 이후, 별도의 추가작업이 필요한지 여부를 응답하는 `additional-auth-required` 파라미터를 함께 응답합니다.
`additional-auth-required` 파라미터 값이 `true`이면 본인인증 정보를 기입하는 추가작업이 필요하다는 의미이고, `false`이면 추가작업이 필요 없다는 의미입니다.


### Member 엔티티 분리
기존에 Member 엔티티에는 일반 로그인 정보(로그인 아이디, 비밀번호), 본인인증 정보(이름, 전화번호, 생년월일 등)와 같은 정보들이 담겨있었습니다.
하지만 저희 서비스는 일반 로그인과 소셜 로그인을 동시에 지원해야하는 시스템입니다.
일반 로그인으로 가입한 유저는 Member 엔티티에 대부분의 데이터가 담겨있지만, 소셜 로그인으로 가입한 유저는 loginId, password 데이터가 없습니다.
이대로 두면 너무 많은 null을 허용하기에 좋은 설계가 아니라고 생각하여 아래와 같이 엔티티를 분리했습니다.

- `Member` (식별값, 계정타입[Social || Normal], 상태[인증 미완료 || 인증 완료 || 탈퇴])
- `SocialAccount` (소셜 로그인 계정 정보)
- `NormalAccount` (로그인 아이디, 비밀번호, 이메일)
- `MemberInfoDetail` (본인인증 정보 - 이름, 생년월일, 전화번호 등 추가 입력) : 아직 작성 안함


### JwtAuthenticationFilter
`JwtAuthenticationFilter`는 요청에서 AccessToken을 읽어 검증하고, Authentication 객체를 생성해서 SecurityContext에 담아줍니다.