### PR TITLE
주문, 결제 수정

### DIFF
--- a/src/main/java/com/safeking/shop/domain/item/domain/entity/Item.java
+++ b/src/main/java/com/safeking/shop/domain/item/domain/entity/Item.java
@@ -3,6 +3,7 @@ package com.safeking.shop.domain.item.domain.entity;
 import com.safeking.shop.domain.common.BaseTimeEntity;
 import com.safeking.shop.domain.admin.domain.entity.Admin;
 import com.safeking.shop.domain.exception.ItemException;
+import com.safeking.shop.domain.order.domain.entity.OrderItem;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,8 @@ import org.junit.experimental.categories.Categories;
 
 import javax.annotation.Nullable;
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity @Getter@Setter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
@@ -47,6 +50,12 @@ public class Item extends BaseTimeEntity {
 
     @Nullable
     private int viewPrice;
+
+    /**
+     * 양방향 관계로 설정
+     */
+    @OneToMany(mappedBy = "item")
+    private List<ItemPhoto> itemPhotos = new ArrayList<>();
 
     public static Item createItem(String name, int quantity, String description,int price, String adminId, Category category, int viewPrice, String viewYn){
 
@@ -113,6 +122,12 @@ public class Item extends BaseTimeEntity {
      */
     public void addItemQuantity(int count) {
         this.quantity += count;
+    }
+
+    // 연관관계 편의 메소드
+    private void changeItemPhoto(ItemPhoto itemPhoto) {
+        this.itemPhotos.add(itemPhoto);
+        itemPhoto.changeItem(this);
     }
 
 }

--- a/src/main/java/com/safeking/shop/domain/item/domain/entity/ItemPhoto.java
+++ b/src/main/java/com/safeking/shop/domain/item/domain/entity/ItemPhoto.java
@@ -17,6 +17,10 @@ public class ItemPhoto extends BaseTimeEntity {
 
     private String fileName;
 
+    /**
+     * 양방향 관계로 설정
+     * ItemPhoto가 연관관계 주인
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
@@ -26,6 +30,10 @@ public class ItemPhoto extends BaseTimeEntity {
         itemPhoto.fileName = fileName;
         itemPhoto.item = item;
         return  itemPhoto;
+    }
+
+    public void changeItem(Item item) {
+        this.item = item;
     }
 
 }

--- a/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
@@ -78,6 +78,7 @@ public class Order extends BaseTimeEntity {
         }
     }
 
+    // 연관관계 편의 메소드
     private void changeOrderItem(OrderItem orderItem) {
         this.orderItems.add(orderItem);
         orderItem.changeOrder(this);

--- a/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
@@ -114,4 +114,8 @@ public class Order extends BaseTimeEntity {
     public void changeMerchantUid(String merchantUid) {
         this.merchantUid = merchantUid;
     }
+
+    public void changeOrderStatus(OrderStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderItemRepository.java
@@ -20,4 +20,16 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     @Query("delete from OrderItem oi where oi in :orderItems")
     void deleteByOrderBatch(@Param("orderItems") List<OrderItem> orderItems);
 
+    /**
+     * 참고: 벌크 연산은 영속성 컨텍스트를 무시하고 실행하기 때문에,
+     * 영속성 컨텍스트에 있는 엔티티의 상태와 DB에 엔티티 상태가 달라질 수 있다.
+     *
+     * > 권장 방안
+     * > 1. 영속성 컨텍스트에 엔티티가 없는 상태에서 벌크 연산을 먼저 실행한다.
+     * > 2. 부득이하게 영속성 컨텍스트에 엔티티가 있으면 벌크 연산 직후 영속성 컨텍스트를 초기화 한다.
+     */
+    @Modifying(clearAutomatically = true) // 벌크성 쿼리 실행 후 영속성 컨텍스트 초기화
+    @Query("delete from OrderItem oi where oi in :orderItems")
+    void deleteAllByOrderItems(@Param("orderItems") List<OrderItem> orderItems);
+
 }

--- a/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
@@ -24,6 +24,7 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
             " join fetch o.orderItems oi" +
             " join fetch o.safeKingPayment p" +
             " join fetch oi.item i" +
+            " join fetch ItemPhoto ip on i.id = ip.id" +
             " where o.id = :id")
     Optional<Order> findOrderDetail(@Param("id") Long id);
 //    @Query("select o from Order o" +

--- a/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
@@ -22,9 +22,9 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
     @Query("select o from Order o" +
             " join fetch o.delivery d" +
             " join fetch o.orderItems oi" +
-            " join fetch o.safeKingPayment p" +
+            " join fetch o.safeKingPayment sp" +
             " join fetch oi.item i" +
-            " join fetch ItemPhoto ip on i.id = ip.id" +
+            " join fetch ItemPhoto ip on ip.item = i" +
             " where o.id = :id")
     Optional<Order> findOrderDetail(@Param("id") Long id);
 //    @Query("select o from Order o" +

--- a/src/main/java/com/safeking/shop/domain/order/domain/service/OrderService.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/service/OrderService.java
@@ -6,6 +6,8 @@ import com.safeking.shop.domain.order.web.dto.request.user.cancel.CancelRequest;
 import com.safeking.shop.domain.order.web.dto.request.user.order.OrderRequest;
 import com.safeking.shop.domain.order.web.dto.request.user.modify.ModifyInfoRequest;
 import com.safeking.shop.domain.order.web.dto.request.user.search.OrderSearchCondition;
+import com.safeking.shop.domain.order.web.dto.response.admin.orderdetail.AdminOrderDetailResponse;
+import com.safeking.shop.domain.order.web.dto.response.user.orderdetail.OrderDetailResponse;
 import com.safeking.shop.domain.user.domain.entity.member.Member;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import org.springframework.data.domain.Page;
@@ -16,7 +18,8 @@ import java.io.IOException;
 public interface OrderService {
 
     Order searchOrder(Long id); //주문 단건 조회
-    Order searchOrderDetail(Long id); //주문 상세 조회
+    OrderDetailResponse searchOrderDetailByUser(Long id); //주문 상세 조회(유저)
+    AdminOrderDetailResponse searchOrderDetailByAdmin(Long id); //주문 상세 조회(어드민)
     Page<Order> searchOrders(Pageable pageable, OrderSearchCondition condition, Long memberId); //주문 다건 조회
     void cancel(CancelRequest cancelRequest); //주문 취소
     Long order(Member member, OrderRequest orderRequest); //주문

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
@@ -35,6 +35,9 @@ public class OrderAdminController {
     private final OrderService orderService;
     private final ValidationOrderService validationOrderService;
 
+    /**
+     * 관리자 주문 상세 조회
+     */
     @GetMapping("/order/detail/{orderId}")
     public ResponseEntity<AdminOrderDetailResponse> searchOrderDetailByAdmin(@PathVariable("orderId") Long orderId,
                                                                              HttpServletRequest request) {

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
@@ -46,66 +46,7 @@ public class OrderAdminController {
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         // 주문 상세 조회
-        Order findOrderDetail = orderService.searchOrderDetail(orderId);
-
-        return new ResponseEntity<>(getOrderDetailResponse(findOrderDetail), OK);
-    }
-
-    private AdminOrderDetailResponse getOrderDetailResponse(Order findOrderDetail) {
-
-        // 주문 상세 조회 응답 데이터
-        List<AdminOrderDetailOrderItemsResponse> orderItems = findOrderDetail.getOrderItems().stream()
-                .map(oi -> AdminOrderDetailOrderItemsResponse.builder()
-                        .id(oi.getId())
-                        .name(oi.getItem().getName())
-                        .count(oi.getCount())
-                        .price(oi.getOrderPrice())
-                        .build())
-                .collect(Collectors.toList());
-
-        /**
-         * 추후, 결제 API에서 데이터 수집해야함.
-         */
-        AdminOrderDetailDeliveryResponse delivery = AdminOrderDetailDeliveryResponse.builder()
-                .id(findOrderDetail.getDelivery().getId())
-                .status(findOrderDetail.getDelivery().getStatus().getDescription())
-                .receiver(findOrderDetail.getDelivery().getReceiver())
-                .phoneNumber(findOrderDetail.getDelivery().getPhoneNumber())
-                .address(findOrderDetail.getDelivery().getAddress())
-                .memo(findOrderDetail.getDelivery().getMemo())
-                .invoiceNumber(findOrderDetail.getDelivery().getInvoiceNumber())
-                .cost(findOrderDetail.getDelivery().getCost())
-                .company(findOrderDetail.getDelivery().getCompany())
-                .build();
-
-        /**
-         * 추후, 결제 API에서 데이터 수집해야함.
-         */
-        AdminOrderDetailPaymentResponse payment = AdminOrderDetailPaymentResponse.builder()
-                .status(findOrderDetail.getSafeKingPayment().getStatus().getDescription())
-                .company(findOrderDetail.getSafeKingPayment().getCardCode())
-                .means(findOrderDetail.getSafeKingPayment().getPayMethod())
-                .price(findOrderDetail.getSafeKingPayment().getAmount())
-                .build();
-
-        AdminOrderDetailOrderResponse order = AdminOrderDetailOrderResponse.builder()
-                .id(findOrderDetail.getId())
-                .status(findOrderDetail.getStatus().getDescription())
-                .price(findOrderDetail.getSafeKingPayment().getAmount())
-                .memo(findOrderDetail.getMemo())
-                .date(findOrderDetail.getCreateDate())
-                .adminMemo(findOrderDetail.getAdminMemo())
-                .orderItems(orderItems)
-                .payment(payment)
-                .delivery(delivery)
-                .build();
-
-        AdminOrderDetailResponse adminOrderDetailResponse = AdminOrderDetailResponse.builder()
-                .message(ADMIN_ORDER_DETAIL_FIND_SUCCESS)
-                .order(order)
-                .build();
-
-        return adminOrderDetailResponse;
+        return new ResponseEntity<>(orderService.searchOrderDetailByAdmin(orderId), OK);
     }
 
     /**
@@ -168,6 +109,7 @@ public class OrderAdminController {
 
             AdminOrderListOrderResponse order = AdminOrderListOrderResponse.builder()
                     .id(o.getId())
+                    .merchantUid(o.getMerchantUid())
                     .status(o.getStatus().getDescription())
                     .price(o.getSafeKingPayment().getAmount())
                     .date(o.getCreateDate())

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
@@ -116,6 +116,7 @@ public class OrderController {
         OrderOrderResponse order = OrderOrderResponse.builder()
                 .id(findOrder.getId())
                 .memo(findOrder.getMemo())
+                .merchantUid(findOrder.getMerchantUid())
                 .build();
 
         OrderResponse orderResponse = OrderResponse.builder()
@@ -136,52 +137,7 @@ public class OrderController {
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         // 주문 상세 조회
-        Order findOrderDetail = orderService.searchOrderDetail(orderId);
-
-        return new ResponseEntity<>(getOrderDetailResponse(findOrderDetail), OK);
-    }
-
-    private OrderDetailResponse getOrderDetailResponse(Order findOrderDetail) {
-
-        // 주문 상세 조회 응답 데이터
-        List<OrderDetailOrderItemResponse> orderItems = findOrderDetail.getOrderItems().stream()
-                .map(oi -> OrderDetailOrderItemResponse.builder()
-                        .id(oi.getId())
-                        .name(oi.getItem().getName())
-                        .count(oi.getCount())
-                        .price(oi.getOrderPrice())
-                        .build())
-                .collect(Collectors.toList());
-
-        OrderDetailDeliveryResponse delivery = OrderDetailDeliveryResponse.builder()
-                .id(findOrderDetail.getDelivery().getId())
-                .status(findOrderDetail.getDelivery().getStatus().getDescription())
-                .receiver(findOrderDetail.getDelivery().getReceiver())
-                .phoneNumber(findOrderDetail.getDelivery().getPhoneNumber())
-                .address(findOrderDetail.getDelivery().getAddress())
-                .memo(findOrderDetail.getDelivery().getMemo())
-                .cost(findOrderDetail.getDelivery().getCost())
-                .build();
-
-        OrderDetailPaymentResponse payment = OrderDetailPaymentResponse.builder()
-                .status(findOrderDetail.getSafeKingPayment().getStatus().getDescription())
-                .build();
-
-        OrderDetailOrderResponse order = OrderDetailOrderResponse.builder()
-                .id(findOrderDetail.getId())
-                .status(findOrderDetail.getStatus().getDescription())
-                .price(findOrderDetail.getSafeKingPayment().getAmount())
-                .memo(findOrderDetail.getMemo())
-                .date(findOrderDetail.getCreateDate())
-                .orderItems(orderItems)
-                .payment(payment)
-                .delivery(delivery)
-                .build();
-
-        return OrderDetailResponse.builder()
-                .message(ORDER_DETAIL_FIND_SUCCESS)
-                .order(order)
-                .build();
+        return new ResponseEntity<>(orderService.searchOrderDetailByUser(orderId), OK);
     }
 
     /**
@@ -216,6 +172,7 @@ public class OrderController {
 
             OrderListOrdersResponse order = OrderListOrdersResponse.builder()
                     .id(o.getId())
+                    .merchantUid(o.getMerchantUid())
                     .status(o.getStatus().getDescription())
                     .price(o.getSafeKingPayment().getAmount())
                     .date(o.getCreateDate())

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailOrderItemsResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailOrderItemsResponse.java
@@ -12,12 +12,14 @@ public class AdminOrderDetailOrderItemsResponse {
     private String name;
     private int count;
     private int price;
+    private String thumbnail;
 
     @Builder
-    public AdminOrderDetailOrderItemsResponse(Long id, String name, int count, int price) {
+    public AdminOrderDetailOrderItemsResponse(Long id, String name, int count, int price, String thumbnail) {
         this.id = id;
         this.name = name;
         this.count = count;
         this.price = price;
+        this.thumbnail = thumbnail;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailOrderResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailOrderResponse.java
@@ -21,9 +21,10 @@ public class AdminOrderDetailOrderResponse {
     private List<AdminOrderDetailOrderItemsResponse> orderItems;
     private AdminOrderDetailDeliveryResponse delivery;
     private AdminOrderDetailPaymentResponse payment;
+    private String merchantUid;
 
     @Builder
-    public AdminOrderDetailOrderResponse(Long id, String status, int price, String memo, LocalDateTime date, String adminMemo, List<AdminOrderDetailOrderItemsResponse> orderItems, AdminOrderDetailDeliveryResponse delivery, AdminOrderDetailPaymentResponse payment) {
+    public AdminOrderDetailOrderResponse(Long id, String status, int price, String memo, LocalDateTime date, String adminMemo, List<AdminOrderDetailOrderItemsResponse> orderItems, AdminOrderDetailDeliveryResponse delivery, AdminOrderDetailPaymentResponse payment, String merchantUid) {
         this.id = id;
         this.status = status;
         this.price = price;
@@ -33,5 +34,6 @@ public class AdminOrderDetailOrderResponse {
         this.orderItems = orderItems;
         this.delivery = delivery;
         this.payment = payment;
+        this.merchantUid = merchantUid;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailPaymentResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailPaymentResponse.java
@@ -11,15 +11,13 @@ public class AdminOrderDetailPaymentResponse {
     private String status;
     private String company;
     private String means;
-    private String businessNumber;
     private int price;
 
     @Builder
-    public AdminOrderDetailPaymentResponse(String status, String company, String means, String businessNumber, int price) {
+    public AdminOrderDetailPaymentResponse(String status, String company, String means, int price) {
         this.status = status;
         this.company = company;
         this.means = means;
-        this.businessNumber = businessNumber;
         this.price = price;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/search/AdminOrderListOrderResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/search/AdminOrderListOrderResponse.java
@@ -20,9 +20,10 @@ public class AdminOrderListOrderResponse {
     private AdminOrderListPaymentResponse payment;
     private AdminOrderListMemberResponse member;
     private AdminOrderListDeliveryResponse delivery;
+    private String merchantUid;
 
     @Builder
-    public AdminOrderListOrderResponse(Long id, String status, int price, LocalDateTime date, int orderItemCount, AdminOrderListOrderItemResponse orderItem, AdminOrderListPaymentResponse payment, AdminOrderListMemberResponse member, AdminOrderListDeliveryResponse delivery) {
+    public AdminOrderListOrderResponse(Long id, String status, int price, LocalDateTime date, int orderItemCount, AdminOrderListOrderItemResponse orderItem, AdminOrderListPaymentResponse payment, AdminOrderListMemberResponse member, AdminOrderListDeliveryResponse delivery, String merchantUid) {
         this.id = id;
         this.status = status;
         this.price = price;
@@ -32,5 +33,6 @@ public class AdminOrderListOrderResponse {
         this.payment = payment;
         this.member = member;
         this.delivery = delivery;
+        this.merchantUid = merchantUid;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/order/OrderOrderResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/order/OrderOrderResponse.java
@@ -10,10 +10,12 @@ import lombok.Data;
 public class OrderOrderResponse {
     private Long id;
     private String memo;
+    private String merchantUid;
 
     @Builder
-    public OrderOrderResponse(Long id, String memo) {
+    public OrderOrderResponse(Long id, String memo, String merchantUid) {
         this.id = id;
         this.memo = memo;
+        this.merchantUid = merchantUid;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/orderdetail/OrderDetailOrderItemResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/orderdetail/OrderDetailOrderItemResponse.java
@@ -12,12 +12,14 @@ public class OrderDetailOrderItemResponse {
     private String name;
     private int count;
     private int price;
+    private String thumbnail;
 
     @Builder
-    public OrderDetailOrderItemResponse(Long id, String name, int count, int price) {
+    public OrderDetailOrderItemResponse(Long id, String name, int count, int price, String thumbnail) {
         this.id = id;
         this.name = name;
         this.count = count;
         this.price = price;
+        this.thumbnail = thumbnail;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/orderdetail/OrderDetailOrderResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/orderdetail/OrderDetailOrderResponse.java
@@ -20,9 +20,10 @@ public class OrderDetailOrderResponse {
     private List<OrderDetailOrderItemResponse> orderItems;
     private OrderDetailPaymentResponse payment;
     private OrderDetailDeliveryResponse delivery;
+    private String merchantUid;
 
     @Builder
-    public OrderDetailOrderResponse(Long id, String status, int price, String memo, LocalDateTime date, List<OrderDetailOrderItemResponse> orderItems, OrderDetailPaymentResponse payment, OrderDetailDeliveryResponse delivery) {
+    public OrderDetailOrderResponse(Long id, String status, int price, String memo, LocalDateTime date, List<OrderDetailOrderItemResponse> orderItems, OrderDetailPaymentResponse payment, OrderDetailDeliveryResponse delivery, String merchantUid) {
         this.id = id;
         this.status = status;
         this.price = price;
@@ -31,5 +32,6 @@ public class OrderDetailOrderResponse {
         this.orderItems = orderItems;
         this.payment = payment;
         this.delivery = delivery;
+        this.merchantUid = merchantUid;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListOrdersResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListOrdersResponse.java
@@ -18,9 +18,10 @@ public class OrderListOrdersResponse {
     private int count;
     private OrderListOrderItemResponse orderItem;
     private OrderListPaymentResponse payment;
+    private String merchantUid;
 
     @Builder
-    public OrderListOrdersResponse(Long id, String status, int price, LocalDateTime date, int count, OrderListOrderItemResponse orderItem, OrderListPaymentResponse payment) {
+    public OrderListOrdersResponse(Long id, String status, int price, LocalDateTime date, int count, OrderListOrderItemResponse orderItem, OrderListPaymentResponse payment, String merchantUid) {
         this.id = id;
         this.status = status;
         this.price = price;
@@ -28,5 +29,6 @@ public class OrderListOrdersResponse {
         this.count = count;
         this.orderItem = orderItem;
         this.payment = payment;
+        this.merchantUid = merchantUid;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/query/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/query/repository/OrderRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.safeking.shop.domain.order.domain.entity.Order;
 import com.safeking.shop.domain.order.domain.entity.status.DeliveryStatus;
 import com.safeking.shop.domain.payment.domain.entity.PaymentStatus;
 import com.safeking.shop.domain.order.web.dto.request.user.search.OrderSearchCondition;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -27,15 +28,10 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 import static org.springframework.util.StringUtils.*;
 
 @Repository
+@RequiredArgsConstructor
 public class OrderRepositoryImpl implements OrderRepositoryCustom {
 
-    private final EntityManager em;
     private final JPAQueryFactory queryFactory;
-
-    public OrderRepositoryImpl(EntityManager em) {
-        this.em = em;
-        this.queryFactory = new JPAQueryFactory(em);
-    }
 
     @Override
     public Page<Order> findOrders(Pageable pageable, OrderSearchCondition condition, Long memberId) {

--- a/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
+++ b/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
@@ -2,7 +2,7 @@ package com.safeking.shop.domain.payment.constant;
 
 public class SafeKingPaymentConst {
     public static final String PAYMENT_PAID_SUCCESS = "결제 완료";
-    public static final String PAYMENT_PAID_FAILED = "결제 실패";
+    public static final String PAYMENT_PAID_CANCEL = "결제 취소";
     public static final String SAFEKING_PAYMENT_NONE = "DB에 결제 내역이 없습니다. 주문 후에 결제 해주세요.";
     public static final String PAYMENT_AMOUNT_ERROR_WEBHOOK = "결제 금액 검증 에러 발생(웹훅)";
     public static final String PAYMENT_AMOUNT_ERROR_CALLBACK = "결제 금액 검증 에러 발생(콜백)";

--- a/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
+++ b/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
@@ -4,6 +4,7 @@ public class SafeKingPaymentConst {
     public static final String PAYMENT_PAID_SUCCESS = "결제 완료";
     public static final String PAYMENT_PAID_FAILED = "결제 실패";
     public static final String SAFEKING_PAYMENT_NONE = "DB에 결제 내역이 없습니다. 주문 후에 결제 해주세요.";
-    public static final String PAYMENT_AMOUNT_ERROR = "결제 금액 검증 에러 발생";
+    public static final String PAYMENT_AMOUNT_ERROR_WEBHOOK = "결제 금액 검증 에러 발생(웹훅)";
+    public static final String PAYMENT_AMOUNT_ERROR_CALLBACK = "결제 금액 검증 에러 발생(콜백)";
     public static final String IAMPORT_PAYMENT_ERROR = "아임포트 에러 발생";
 }

--- a/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
+++ b/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
@@ -4,7 +4,7 @@ public class SafeKingPaymentConst {
     public static final String PAYMENT_PAID_SUCCESS = "결제 완료";
     public static final String PAYMENT_PAID_CANCEL = "결제 취소";
     public static final String SAFEKING_PAYMENT_NONE = "DB에 결제 내역이 없습니다. 주문 후에 결제 해주세요.";
-    public static final String PAYMENT_AMOUNT_ERROR_WEBHOOK = "결제 금액 검증 에러 발생(웹훅)";
-    public static final String PAYMENT_AMOUNT_ERROR_CALLBACK = "결제 금액 검증 에러 발생(콜백)";
+    public static final String PAYMENT_AMOUNT_DIFFERENT_WEBHOOK = "가맹점 결제금액과 요청 결제금액이 다릅니다.(웹훅)";
+    public static final String PAYMENT_AMOUNT_DIFFERENT_CALLBACK = "가맹점 결제금액과 요청 결제금액이 다릅니다.(콜백)";
     public static final String IAMPORT_PAYMENT_ERROR = "아임포트 에러 발생";
 }

--- a/src/main/java/com/safeking/shop/domain/payment/domain/entity/CustomCardCodeConstant.java
+++ b/src/main/java/com/safeking/shop/domain/payment/domain/entity/CustomCardCodeConstant.java
@@ -1,0 +1,58 @@
+package com.safeking.shop.domain.payment.domain.entity;
+
+import com.siot.IamportRestClient.constant.CardConstant;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+public final class CustomCardCodeConstant {
+    /**
+     * 361	BC카드
+     * 364	광주카드
+     * 365	삼성카드
+     * 366	신한카드
+     * 367	현대카드
+     * 368	롯데카드
+     * 369	수협카드
+     * 370	씨티카드
+     * 371	NH카드
+     * 372	전북카드
+     * 373	제주카드
+     * 374	하나카드
+     * 381	KB국민카드
+     * 041	우리카드
+     * 071	우체국
+     * VIS	해외비자
+     * MAS	해외마스터
+     * DIN	해외다이너스
+     * AMX	해외AMEX
+     * JCB	해외JCB
+     * UNI	중국은련
+     */
+    public static final String KR_CODE_BC = "BC카드";
+    public static final String KR_CODE_KWANGJU = "광주카드";
+    public static final String KR_CODE_SAMSUNG = "삼성카드";
+    public static final String KR_CODE_SHINHAN = "신한카드";
+    public static final String KR_CODE_HYUNDAI = "현대카드";
+    public static final String KR_CODE_LOTTE = "롯데카드";
+    public static final String KR_CODE_SUHYUP = "수협카드";
+    public static final String KR_CODE_CITI = "씨티카드";
+    public static final String KR_CODE_NH = "NH카드";
+    public static final String KR_CODE_JEONBUK = "전북카드";
+    public static final String KR_CODE_JEJU = "제주카드";
+    public static final String KR_CODE_HANA = "하나카드";
+    public static final String KR_CODE_KB = "KB국민카드";
+    public static final String KR_CODE_WOORI = "우리카드";
+    public static final String KR_CODE_EPOST = "우체국";
+    public static final String KR_CODE_VISA = "해외비자";
+    public static final String KR_CODE_MASTER = "해외마스터";
+    public static final String KR_CODE_DINERS = "해외다이너스";
+    public static final String KR_CODE_AMEX = "해외AMEX";
+    public static final String KR_CODE_JCB = "해외JCB";
+    public static final String KR_CODE_UNION = "중국은련";
+}

--- a/src/main/java/com/safeking/shop/domain/payment/domain/entity/SafekingPayment.java
+++ b/src/main/java/com/safeking/shop/domain/payment/domain/entity/SafekingPayment.java
@@ -9,12 +9,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import static com.safeking.shop.domain.order.constant.OrderConst.DeliveryCost;
 import static com.safeking.shop.domain.payment.domain.entity.PaymentStatus.*;
+import static org.junit.rules.Timeout.millis;
 
 /**
  * 금액은 Integer로 선언(21억까지 가능)
@@ -41,15 +47,15 @@ public class SafekingPayment extends BaseTimeEntity {
     private String bankCode;// 은행 표준코드 - (금융결제원기준)
     private String bankName; // 은행 명칭 - (실시간계좌이체 결제 건의 경우)
     private String cardCode; // 카드사 코드번호
-    private String cardQuota; // 할부개월 수(0이면 일시불)
+    private int cardQuota; // 할부개월 수(0이면 일시불)
     private String cardNumber; // 결제에 사용된 마스킹된 카드번호. 7~12번째 자리를 마스킹하는 것이 일반적이지만, PG사의 정책/설정에 따라 다소 차이가 있을 수 있음
     private String cardType; // 카드유형. (주의)해당 정보를 제공하지 않는 일부 PG사의 경우 null 로 응답됨(ex. JTNet, 이니시스-빌링) = ['null', '0(신용카드)', '1(체크카드)']
     private String vbankCode; // 가상계좌 은행 표준코드 - (금융결제원기준)
     private String vbankName; // 입금받을 가상계좌 은행명
     private String vbankNum; // 입금받을 가상계좌 계좌번호
     private String vbankHolder; // 입금받을 가상계좌 예금주
-    private String vbankDate; // 입금받을 가상계좌 마감기한 UNIX timestamp
-    private String vbankIssuedAt; // 가상계좌 생성 시각 UNIX timestamp
+    private Date vbankDate; // 입금받을 가상계좌 마감기한 UNIX timestamp
+    private LocalDateTime vbankIssuedAt; // 가상계좌 생성 시각 UNIX timestamp
     private String name; // 주문명칭
     private Integer amount; // 주문(결제)금액
     private Integer cancelAmount; // 결제취소금액
@@ -63,10 +69,10 @@ public class SafekingPayment extends BaseTimeEntity {
     private String customData; // 가맹점에서 전달한 custom data. JSON string으로 전달
     private String userAgent;
 //    private String status; // -> PaymentStatus status로 대체
-    private Long startedAt; // 결제시작시점 UNIX timestamp. IMP.request_pay() 를 통해 결제창을 최초 오픈한 시각
+    private LocalDateTime startedAt; // 결제시작시점 UNIX timestamp. IMP.request_pay() 를 통해 결제창을 최초 오픈한 시각
     private Date paidAt; // 결제완료시점 UNIX timestamp. 결제완료가 아닐 경우 0
-    private Long failedAt; // 결제실패시점 UNIX timestamp. 결제실패가 아닐 경우 0
-    private Long cancelledAt; // 결제취소시점 UNIX timestamp. 결제취소가 아닐 경우 0
+    private LocalDateTime failedAt; // 결제실패시점 UNIX timestamp. 결제실패가 아닐 경우 0
+    private LocalDateTime cancelledAt; // 결제취소시점 UNIX timestamp. 결제취소가 아닐 경우 0
     private String failReason; // 결제실패 사유
     private String cancelReason; // 결제취소 사유
     private String receiptUrl; // 신용카드 매출전표 확인 URL
@@ -132,15 +138,15 @@ public class SafekingPayment extends BaseTimeEntity {
         this.bankCode = response.getBankCode();
         this.bankName = response.getBankName();
         this.cardCode = response.getCardCode();
-        this.cardQuota = response.getCardCode();
+        this.cardQuota = response.getCardQuota();
         this.cardNumber = response.getCardNumber();
         this.cardType = response.getCardCode();
         this.vbankCode = response.getVbankCode();
         this.vbankName = response.getVbankName();
         this.vbankNum = response.getVbankNum();
         this.vbankHolder = response.getVbankHolder();
-        this.vbankDate = response.getVbankCode();
-        this.vbankIssuedAt = response.getVbankCode();
+        this.vbankDate = response.getVbankDate();
+        this.vbankIssuedAt = convertUNIXTimeStampToLocalDateTime(response.getVbankIssuedAt());
         this.name = response.getName();
         this.amount = response.getAmount().intValue();
         this.cancelAmount = response.getCancelAmount().intValue();
@@ -152,14 +158,22 @@ public class SafekingPayment extends BaseTimeEntity {
         this.buyerPostcode = response.getBuyerPostcode();
         this.customData = response.getCustomData();
         this.userAgent = response.getApplyNum();
-        this.startedAt = response.getStartedAt();
+        this.startedAt = convertUNIXTimeStampToLocalDateTime(response.getStartedAt());
         this.paidAt = response.getPaidAt();
-        this.failedAt = response.getStartedAt();
-        this.cancelledAt = response.getStartedAt();
+        this.failedAt = convertUNIXTimeStampToLocalDateTime(response.getStartedAt());
+        this.cancelledAt = convertUNIXTimeStampToLocalDateTime(response.getStartedAt());
         this.failReason = response.getFailReason();
         this.cancelReason = response.getCancelReason();
         this.receiptUrl = response.getReceiptUrl();
         this.customerUid = response.getCustomerUid();
         this.customerUidUsage = response.getCustomerUidUsage();
+    }
+
+    private LocalDateTime convertUNIXTimeStampToLocalDateTime(Long unixTimeStamp) {
+        LocalDateTime localDateTime =
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTimeStamp),
+                        TimeZone.getDefault().toZoneId());
+
+        return localDateTime;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/payment/domain/repository/CustomCardCodeRepository.java
+++ b/src/main/java/com/safeking/shop/domain/payment/domain/repository/CustomCardCodeRepository.java
@@ -1,0 +1,48 @@
+package com.safeking.shop.domain.payment.domain.repository;
+
+import com.safeking.shop.domain.payment.domain.entity.CustomCardCodeConstant;
+import com.siot.IamportRestClient.constant.CardConstant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.safeking.shop.domain.payment.domain.entity.CustomCardCodeConstant.*;
+import static com.safeking.shop.domain.payment.domain.entity.CustomCardCodeConstant.KR_CODE_LOTTE;
+import static com.siot.IamportRestClient.constant.CardConstant.*;
+
+@Repository
+public class CustomCardCodeRepository {
+    private final static Map<String, String> cardCodeMap = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public static void init() {
+        cardCodeMap.put(CODE_BC, KR_CODE_BC);
+        cardCodeMap.put(CODE_KWANGJU, KR_CODE_KWANGJU);
+        cardCodeMap.put(CODE_SAMSUNG, KR_CODE_SAMSUNG);
+        cardCodeMap.put(CODE_SHINHAN, KR_CODE_SHINHAN);
+        cardCodeMap.put(CODE_HYUNDAI, KR_CODE_HYUNDAI);
+        cardCodeMap.put(CODE_LOTTE, KR_CODE_LOTTE);
+        cardCodeMap.put(CODE_SUHYUP, KR_CODE_SUHYUP);
+        cardCodeMap.put(CODE_CITI, KR_CODE_CITI);
+        cardCodeMap.put(CODE_NH, KR_CODE_NH);
+        cardCodeMap.put(CODE_JEONBUK, KR_CODE_JEONBUK);
+        cardCodeMap.put(CODE_JEJU, KR_CODE_JEJU);
+        cardCodeMap.put(CODE_HANA, KR_CODE_HANA);
+        cardCodeMap.put(CODE_KB, KR_CODE_KB);
+        cardCodeMap.put(CODE_WOORI, KR_CODE_WOORI);
+        cardCodeMap.put(CODE_EPOST, KR_CODE_EPOST);
+        cardCodeMap.put(CODE_VISA, KR_CODE_VISA);
+        cardCodeMap.put(CODE_MASTER, KR_CODE_MASTER);
+        cardCodeMap.put(CODE_DINERS, KR_CODE_DINERS);
+        cardCodeMap.put(CODE_AMEX, KR_CODE_AMEX);
+        cardCodeMap.put(CODE_JCB, KR_CODE_JCB);
+        cardCodeMap.put(CODE_UNION, KR_CODE_UNION);
+    }
+
+    public static String getElement(String key) {
+        return cardCodeMap.get(key);
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCallbackRequest.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCallbackRequest.java
@@ -21,4 +21,5 @@ public class PaymentCallbackRequest {
     private String merchantUid; //주문 번호
     @NotNull(message = "결제 금액이 null 입니다.")
     private Integer paidAmount; // 결제 금액
+    private String errorMsg; // 결제실패 메시지
 }

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCallbackRequest.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCallbackRequest.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PaymentCallbackRequest {
-    @NotNull(message = "결제 성공 여부가 null 입니다.")
+    @NotNull(message = "결제 성공 여부가 빈 값입니다.")
     private Boolean success; // 결제 성공 여부
     @NotBlank(message = "결제 고유 번호가 빈 값입니다.")
     private String impUid; // 결제 고유 번호

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCallbackResponse.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCallbackResponse.java
@@ -17,9 +17,13 @@ public class PaymentCallbackResponse {
     private String buyerTel; // 구매자 연락처
     private String buyerAddr; // 구매자 주소
     private String buyerPostcode; // 구매자 우편번호
+    private String errorMsg; // 결제 실패 메시지
+
+    public PaymentCallbackResponse() {
+    }
 
     @Builder
-    public PaymentCallbackResponse(String payMethod, String merchantUid, String name, Integer amount, String buyerEmail, String buyerName, String buyerTel, String buyerAddr, String buyerPostcode) {
+    public PaymentCallbackResponse(String payMethod, String merchantUid, String name, Integer amount, String buyerEmail, String buyerName, String buyerTel, String buyerAddr, String buyerPostcode, String errorMsg) {
         this.payMethod = payMethod;
         this.merchantUid = merchantUid;
         this.name = name;
@@ -29,5 +33,6 @@ public class PaymentCallbackResponse {
         this.buyerTel = buyerTel;
         this.buyerAddr = buyerAddr;
         this.buyerPostcode = buyerPostcode;
+        this.errorMsg = errorMsg;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
@@ -70,7 +70,7 @@ public class IamportServiceImpl implements IamportService {
             Payment response = iamportResponse.getResponse();
 
             // DB에서 결제 내역 조회
-            SafekingPayment findSafekingPayment = getSafekingPayment(request.getMerchantUid());
+            SafekingPayment findSafekingPayment = iamportServiceSubMethod.getSafekingPayment(request.getMerchantUid());
 
             // 결제 금액 비교(결제 금액이 다르다면)
             if(findSafekingPayment.getAmount() != response.getAmount().intValue()) {
@@ -141,14 +141,14 @@ public class IamportServiceImpl implements IamportService {
             Payment response = iamportResponse.getResponse();
 
             // DB에서 결제 내역 조회
-            SafekingPayment findSafekingPayment = getSafekingPayment(request.getMerchantUid());
+            SafekingPayment findSafekingPayment = iamportServiceSubMethod.getSafekingPayment(request.getMerchantUid());
 
             // 결제 금액 비교(결제 금액이 다르다면)
             if(findSafekingPayment.getAmount() != response.getAmount().intValue()) {
                 // 결제, 주문 취소 로직
                 cancel(request.getImpUid(), response.getMerchantUid(), response.getCancelReason(), findSafekingPayment);
 
-                log.debug("[결제검증 위조] {}",PAYMENT_AMOUNT_DIFFERENT_WEBHOOK);
+                log.debug("[결제검증 위조] {}", PAYMENT_AMOUNT_DIFFERENT_WEBHOOK);
                 return;
             }
 

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
@@ -1,0 +1,101 @@
+package com.safeking.shop.domain.payment.web.client.service;
+
+import com.safeking.shop.domain.exception.OrderException;
+import com.safeking.shop.domain.exception.PaymentException;
+import com.safeking.shop.domain.order.domain.entity.Order;
+import com.safeking.shop.domain.order.domain.entity.OrderItem;
+import com.safeking.shop.domain.order.domain.repository.DeliveryRepository;
+import com.safeking.shop.domain.order.domain.repository.OrderItemRepository;
+import com.safeking.shop.domain.order.domain.repository.OrderRepository;
+import com.safeking.shop.domain.payment.domain.entity.SafekingPayment;
+import com.safeking.shop.domain.payment.domain.repository.SafekingPaymentRepository;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.safeking.shop.domain.order.constant.OrderConst.ORDER_NONE;
+import static com.safeking.shop.domain.payment.constant.SafeKingPaymentConst.SAFEKING_PAYMENT_NONE;
+import static com.safeking.shop.domain.payment.domain.entity.PaymentStatus.CANCEL;
+
+@Service
+@RequiredArgsConstructor
+public class IamportServiceSubMethod {
+
+    private final IamportClient client;
+    private final SafekingPaymentRepository safekingPaymentRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final DeliveryRepository deliveryRepository;
+
+    /**
+     * 결제 취소
+     */
+    @NotNull
+    public IamportResponse<Payment> cancelPayment(String impUid, SafekingPayment findSafekingPayment) throws IamportResponseException, IOException {
+        CancelData cancelData = new CancelData(impUid, true);
+        IamportResponse<Payment> cancelPaymentResponse = client.cancelPaymentByImpUid(cancelData); //imp_uid를 통한 전액취소
+        findSafekingPayment.changeSafekingPayment(CANCEL, cancelPaymentResponse.getResponse()); // 결제 취소 내용으로 갱신
+
+        return cancelPaymentResponse;
+    }
+
+    /**
+     * 주문 취소(주문 상태 변경)
+     */
+    public Order cancelOrder(String merchantUid, String cancelReason) {
+        Optional<Order> orderOptional = orderRepository.findOrderByMerchantUid(merchantUid);
+        Order findOrder = orderOptional.orElseThrow(() -> new OrderException(ORDER_NONE));
+        findOrder.cancel(cancelReason);
+
+        return findOrder;
+    }
+
+    /**
+     * 주문 삭제(주문과 관련된 테이블 삭제)
+     */
+    public void deleteOrder(String merchantUid) {
+        // 주문 조회
+        Optional<Order> orderOptional = orderRepository.findOrderByMerchantUid(merchantUid);
+        Order findOrder = orderOptional.orElseThrow(() -> new OrderException(ORDER_NONE));
+
+        // 상품 재고 증가
+        findOrder.getOrderItems()
+                .forEach(OrderItem::cancel);
+
+        // 결제 삭제
+        safekingPaymentRepository.delete(findOrder.getSafeKingPayment());
+        // 주문 상품 삭제
+        orderItemRepository.deleteAllByOrderItems(findOrder.getOrderItems());
+        // 배송 삭제
+        deliveryRepository.delete(findOrder.getDelivery());
+        // 주문 삭제
+        orderRepository.delete(findOrder);
+    }
+
+    /**
+     * DB에서 결제 내역 조회
+     */
+    public SafekingPayment getSafekingPayment(String merchantUid) {
+        Optional<SafekingPayment> safekingPaymentOptional = safekingPaymentRepository.findByMerchantUid(merchantUid);
+        SafekingPayment findSafekingPayment = safekingPaymentOptional.orElseThrow(() -> new PaymentException(SAFEKING_PAYMENT_NONE));
+
+        return findSafekingPayment;
+    }
+    /**
+     * DB에서 주문 내역 조회
+     */
+    public Order getOrder(String merchantUid) {
+        Optional<Order> optionalOrder = orderRepository.findOrderByMerchantUid(merchantUid);
+        Order findOrder = optionalOrder.orElseThrow(() -> new OrderException(ORDER_NONE));
+
+        return findOrder;
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
@@ -23,7 +23,7 @@ import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/test")
+@RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
 public class PaymentController {
     private final IamportService iamportService;
@@ -36,7 +36,7 @@ public class PaymentController {
     public ResponseEntity<PaymentResponse> payment(@Valid @RequestBody PaymentCallbackRequest paymentCallbackRequest, HttpServletRequest request) {
 
         // 회원 검증
-        //validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
+        validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         PaymentResponse<PaymentCallbackResponse> response = iamportService.paymentByCallback(paymentCallbackRequest);
 

--- a/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
@@ -36,7 +36,7 @@ public class PaymentController {
     public ResponseEntity<PaymentResponse> payment(@Valid @RequestBody PaymentCallbackRequest paymentCallbackRequest, HttpServletRequest request) {
 
         // 회원 검증
-        validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
+        //validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         PaymentResponse<PaymentCallbackResponse> response = iamportService.paymentByCallback(paymentCallbackRequest);
 

--- a/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
@@ -35,6 +35,7 @@ public class PaymentController {
     @PostMapping("/payment")
     public ResponseEntity<PaymentResponse> payment(@Valid @RequestBody PaymentCallbackRequest paymentCallbackRequest, HttpServletRequest request) {
 
+        // 회원 검증
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         PaymentResponse<PaymentCallbackResponse> response = iamportService.paymentByCallback(paymentCallbackRequest);
@@ -60,6 +61,7 @@ public class PaymentController {
     @PostMapping("/payment/cancel")
     public ResponseEntity<IamportResponse<Payment>> cancelPayment(@Valid @RequestBody PaymentCancelRequest paymentCancelRequest, HttpServletRequest request) {
 
+        // 회원 검증
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         // 결제 취소

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev
+    active: seaung

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -21,7 +21,7 @@
                 pg : 'html5_inicis.INIpayTest',
                 pay_method : 'card',
                 // merchant_uid: "IMP"+makeMerchantUid,
-                merchant_uid: "04",
+                merchant_uid: "06",
                 name : '안전모 결제 테스트',
                 amount : 2800,
                 buyer_email : 'safeKing@chai.finance',

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -21,7 +21,7 @@
                 pg : 'html5_inicis.INIpayTest',
                 pay_method : 'card',
                 // merchant_uid: "IMP"+makeMerchantUid,
-                merchant_uid: "6522",
+                merchant_uid: "04",
                 name : '안전모 결제 테스트',
                 amount : 2800,
                 buyer_email : 'safeKing@chai.finance',
@@ -64,8 +64,7 @@
         address : "제주 서귀포시 성산읍 성산리 1",
         memo : "납기일 준수해주세요.",
         delivery_memo : "문앞에 부탁 드립니다.",
-        items :[
-          {
+        items :[{
             id: 1,
             price : 1000,
             count: 1
@@ -74,8 +73,7 @@
             id: 2,
             price : 2000,
             count: 2
-          }
-        ]
+          }]
       };
       jQuery.ajax({
         url: "api/v1/user/order",

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -21,7 +21,7 @@
                 pg : 'html5_inicis.INIpayTest',
                 pay_method : 'card',
                 // merchant_uid: "IMP"+makeMerchantUid,
-                merchant_uid: "06",
+                merchant_uid: "09",
                 name : '안전모 결제 테스트',
                 amount : 2800,
                 buyer_email : 'safeKing@chai.finance',
@@ -51,7 +51,18 @@
                     alert('Please, Check your payment result page!!' + rsp);
                   })
                 } else {
-                  alert("결제에 실패하였습니다. 에러 내용: " + rsp.error_msg);
+                  alert("success? "+ rsp.success+ ", 결제에 실패하였습니다. 에러 내용: " + JSON.stringify(rsp));
+                  jQuery.ajax({
+                    url: "api/v1/test/payment",
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    data: JSON.stringify({
+                      imp_uid: rsp.imp_uid,            // 결제 고유번호
+                      merchant_uid: rsp.merchant_uid,   // 주문번호
+                      paid_amount: rsp.paid_amount, // 결제 금액
+                      success: rsp.success // 결제 성공 여부
+                    })
+                  })
                 }
               });
     }

--- a/src/test/java/com/safeking/shop/domain/payment/convert/ConvertTest.java
+++ b/src/test/java/com/safeking/shop/domain/payment/convert/ConvertTest.java
@@ -1,0 +1,23 @@
+package com.safeking.shop.domain.payment.convert;
+
+import com.safeking.shop.domain.payment.domain.entity.CustomCardCodeConstant;
+import com.safeking.shop.domain.payment.domain.repository.CustomCardCodeRepository;
+import com.siot.IamportRestClient.constant.CardConstant;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.annotation.PostConstruct;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@SpringBootTest
+public class ConvertTest {
+
+    @Test
+    void test() {
+        String element = CustomCardCodeRepository.getElement(CardConstant.CODE_BC);
+        Assertions.assertThat(element).isEqualTo(CustomCardCodeConstant.KR_CODE_BC);
+    }
+}


### PR DESCRIPTION
주문
1. `API` 스펙 변경(노션 참고)
   1. 섬네일 이미지 추가
	   1. 주문관리 상세 조회
	   2. 주문상세 조회
   2. 주문 번호 추가
	   1. 주문(배송) 정보 조회
	   2. 주문 상세 조회
	   3. 주문 다건 조회
	   4. 주문관리 목록 조회
	   5. 주문관리 상세 조회

3. `Entity` 수정
   1. `Item`, `ItemPhoto` 양방향 관계 설정

## 결제
1. 결제 로직 변경
	1. 결제 `success`가 `false` -> 상품재고 증가 + 주문, 배송, 주문상품, 결제 데이터 삭제
	2. 결제 `success`가 `ture` -> 결제검증 fail -> 상품재고증가 + 결제취소(아임포트) + 주문, 결제 상태 변경(결제 검증 위조)
	3. 결제 `success`가 `ture` -> 결제검증 `ture` -> 결제, 결제 상태 변경(완료)

> 결제 검증에서 `fail`인 경우에는 누가 위조요청을 하는지 모니터링을 위해서 **데이터 삭제를 하지 않음**