### PR TITLE
주문, 결제 API 수정

### DIFF
--- a/src/main/java/com/safeking/shop/domain/item/web/controller/ItemController.java
+++ b/src/main/java/com/safeking/shop/domain/item/web/controller/ItemController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 
@@ -35,14 +36,14 @@ public class ItemController {
     private final ItemService itemService;
 
     @PostMapping("admin/item")
-    public Long save(@RequestBody ItemSaveRequest itemSaveRequest, HttpServletRequest request){
+    public Long save(@Valid @RequestBody ItemSaveRequest itemSaveRequest, HttpServletRequest request){
         String username = TokenUtils.verify(request.getHeader(AUTH_HEADER).replace(BEARER, ""));
         itemSaveRequest.setAdminId(username);
         return itemService.save(itemSaveRequest);
     }
 
     @PutMapping("admin/item/{itemId}")
-    public void update(@PathVariable Long itemId, @RequestBody ItemUpdateRequest itemUpdateRequest, HttpServletRequest request){
+    public void update(@PathVariable Long itemId, @Valid @RequestBody ItemUpdateRequest itemUpdateRequest, HttpServletRequest request){
         String username = TokenUtils.verify(request.getHeader(AUTH_HEADER).replace(BEARER, ""));
         itemUpdateRequest.setAdminId(username);
         itemUpdateRequest.setId(itemId);

--- a/src/main/java/com/safeking/shop/domain/item/web/request/ItemSaveRequest.java
+++ b/src/main/java/com/safeking/shop/domain/item/web/request/ItemSaveRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
 @Data
 @Builder
@@ -22,6 +23,7 @@ public class ItemSaveRequest {
 
     private String description;
 
+    @Range(min = 100, message = "최소입력 금액은 100원 입니다.")
     private int price;
 
     private Long categoryId;

--- a/src/main/java/com/safeking/shop/domain/item/web/request/ItemUpdateRequest.java
+++ b/src/main/java/com/safeking/shop/domain/item/web/request/ItemUpdateRequest.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Range;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ public class ItemUpdateRequest {
 
     private String description;
 
+    @Range(min = 100, message = "최소입력 금액은 100원 입니다.")
     private int price;
 
     private String adminId;

--- a/src/main/java/com/safeking/shop/domain/order/constant/OrderConst.java
+++ b/src/main/java/com/safeking/shop/domain/order/constant/OrderConst.java
@@ -20,6 +20,8 @@ public class OrderConst {
     public static final String ORDER_DETAIL_FIND_FAIL = "주문 상세 조회 실패";
     public static final String ORDER_LIST_FIND_SUCCESS = "주문 다건 조회 성공";
     public static final String ORDER_LIST_FIND_FAIL = "주문 다건 조회 실패";
+    public static final String ORDER_LIST_FIND_FAIL_PAYMENT_STATUS = "주문 다건 조회 실패(결제 상태가 올바르지 않습니다.)";
+    public static final String ORDER_LIST_FIND_FAIL_DELIVERY_STATUS = "주문 다건 조회 실패(배송 상태가 올바르지 않습니다.)";
 
     /* 관리자 */
     public static final String ADMIN_ORDER_DETAIL_FIND_SUCCESS = "관리자용 주문 상세 조회 완료";

--- a/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/repository/OrderRepository.java
@@ -20,6 +20,7 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
             " where o.id = :id")
     Optional<Order> findOrder(@Param("id") Long id);
     @Query("select o from Order o" +
+            " join fetch o.member m" +
             " join fetch o.delivery d" +
             " join fetch o.orderItems oi" +
             " join fetch o.safeKingPayment sp" +

--- a/src/main/java/com/safeking/shop/domain/order/domain/service/OrderService.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/service/OrderService.java
@@ -7,6 +7,7 @@ import com.safeking.shop.domain.order.web.dto.request.user.order.OrderRequest;
 import com.safeking.shop.domain.order.web.dto.request.user.modify.ModifyInfoRequest;
 import com.safeking.shop.domain.order.web.dto.request.user.search.OrderSearchCondition;
 import com.safeking.shop.domain.order.web.dto.response.admin.orderdetail.AdminOrderDetailResponse;
+import com.safeking.shop.domain.order.web.dto.response.admin.search.AdminOrderListResponse;
 import com.safeking.shop.domain.order.web.dto.response.user.order.OrderResponse;
 import com.safeking.shop.domain.order.web.dto.response.user.orderdetail.OrderDetailResponse;
 import com.safeking.shop.domain.user.domain.entity.member.Member;
@@ -26,7 +27,7 @@ public interface OrderService {
     OrderResponse order(Member member, OrderRequest orderRequest); //주문
     Long modifyOrder(ModifyInfoRequest modifyInfoRequest); //사용자 주문 정보 수정
     Long modifyOrderByAdmin(AdminModifyInfoRequest modifyInfoRequest, Long orderId); //관리자 주문 정보 수정
-    Page<Order> searchOrdersByAdmin(Pageable pageable, OrderSearchCondition condition);
+    AdminOrderListResponse searchOrdersByAdmin(Pageable pageable, OrderSearchCondition condition);
     void delete(Member member);
     void deleteByMemberBatch(Member member);
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
@@ -78,60 +78,7 @@ public class OrderAdminController {
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         // 주문관리 목록 조회
-        Page<Order> ordersPage = orderService.searchOrdersByAdmin(pageable, condition);
-
-        AdminOrderListResponse adminOrderListResponse = getAdminOrderListResponse(ordersPage);
-
-        return new ResponseEntity<>(adminOrderListResponse, OK);
-    }
-
-    private static AdminOrderListResponse getAdminOrderListResponse(Page<Order> ordersPage) {
-
-        List<AdminOrderListOrderResponse> orders = new ArrayList<>();
-        List<Order> findOrders = ordersPage.getContent();
-
-        for(Order o : findOrders) {
-            AdminOrderListOrderItemResponse orderItem = AdminOrderListOrderItemResponse.builder()
-                    .id(o.getOrderItems().get(0).getItem().getId())
-                    .name(o.getOrderItems().get(0).getItem().getName())
-                    .build();
-
-            AdminOrderListPaymentResponse payment = AdminOrderListPaymentResponse.builder()
-                    .status(o.getSafeKingPayment().getStatus().getDescription())
-                    .build();
-
-            AdminOrderListMemberResponse member = AdminOrderListMemberResponse.builder()
-                    .name(o.getMember().getName())
-                    .build();
-
-            AdminOrderListDeliveryResponse delivery = AdminOrderListDeliveryResponse.builder()
-                    .receiver(o.getDelivery().getReceiver())
-                    .status(o.getDelivery().getStatus().getDescription())
-                    .build();
-
-            AdminOrderListOrderResponse order = AdminOrderListOrderResponse.builder()
-                    .id(o.getId())
-                    .merchantUid(o.getMerchantUid())
-                    .status(o.getStatus().getDescription())
-                    .price(o.getSafeKingPayment().getAmount())
-                    .date(o.getCreateDate())
-                    .orderItemCount(o.getOrderItems().size())
-                    .orderItem(orderItem)
-                    .payment(payment)
-                    .member(member)
-                    .delivery(delivery)
-                    .build();
-
-            orders.add(order);
-        }
-
-        return AdminOrderListResponse.builder()
-                .message(ADMIN_ORDER_LIST_FIND_SUCCESS)
-                .orders(orders)
-                .totalElements(ordersPage.getTotalElements())
-                .totalPages(ordersPage.getTotalPages())
-                .size(ordersPage.getSize())
-                .build();
+        return new ResponseEntity<>(orderService.searchOrdersByAdmin(pageable, condition), OK);
     }
 
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderAdminController.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
@@ -12,10 +12,7 @@ import com.safeking.shop.domain.order.web.dto.response.user.orderinfo.OrderInfoR
 import com.safeking.shop.domain.order.web.dto.response.user.orderinfo.OrderInfoDeliveryResponse;
 import com.safeking.shop.domain.order.web.dto.response.user.orderinfo.OrderInfoOrderResponse;
 import com.safeking.shop.domain.order.web.dto.response.user.orderdetail.*;
-import com.safeking.shop.domain.order.web.dto.response.user.search.OrderListOrderItemResponse;
-import com.safeking.shop.domain.order.web.dto.response.user.search.OrderListOrdersResponse;
-import com.safeking.shop.domain.order.web.dto.response.user.search.OrderListPaymentResponse;
-import com.safeking.shop.domain.order.web.dto.response.user.search.OrderListResponse;
+import com.safeking.shop.domain.order.web.dto.response.user.search.*;
 import com.safeking.shop.domain.order.web.query.service.ValidationOrderService;
 import com.safeking.shop.domain.user.domain.entity.member.Member;
 import lombok.RequiredArgsConstructor;
@@ -172,6 +169,10 @@ public class OrderController {
                     .name(o.getOrderItems().get(0).getItem().getName())
                     .build();
 
+            OrderListDeliveryResponse delivery = OrderListDeliveryResponse.builder()
+                    .status(o.getDelivery().getStatus().getDescription())
+                    .build();
+
             OrderListOrdersResponse order = OrderListOrdersResponse.builder()
                     .id(o.getId())
                     .merchantUid(o.getMerchantUid())
@@ -181,6 +182,7 @@ public class OrderController {
                     .count(o.getOrderItems().size())
                     .orderItem(orderItem)
                     .payment(payment)
+                    .delivery(delivery)
                     .build();
 
             orders.add(order);

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailPaymentResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/admin/orderdetail/AdminOrderDetailPaymentResponse.java
@@ -13,13 +13,15 @@ public class AdminOrderDetailPaymentResponse {
     private String means;
     private int price;
     private String impUid;
+    private String buyerName;
 
     @Builder
-    public AdminOrderDetailPaymentResponse(String status, String company, String means, int price, String impUid) {
+    public AdminOrderDetailPaymentResponse(String status, String company, String means, int price, String impUid, String buyerName) {
         this.status = status;
         this.company = company;
         this.means = means;
         this.price = price;
         this.impUid = impUid;
+        this.buyerName = buyerName;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListDeliveryResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListDeliveryResponse.java
@@ -1,0 +1,17 @@
+package com.safeking.shop.domain.order.web.dto.response.user.search;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OrderListDeliveryResponse {
+    private String status;
+
+    @Builder
+    public OrderListDeliveryResponse(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListOrdersResponse.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/dto/response/user/search/OrderListOrdersResponse.java
@@ -18,10 +18,13 @@ public class OrderListOrdersResponse {
     private int count;
     private OrderListOrderItemResponse orderItem;
     private OrderListPaymentResponse payment;
+    private OrderListDeliveryResponse delivery;
     private String merchantUid;
 
     @Builder
-    public OrderListOrdersResponse(Long id, String status, int price, LocalDateTime date, int count, OrderListOrderItemResponse orderItem, OrderListPaymentResponse payment, String merchantUid) {
+    public OrderListOrdersResponse(Long id, String status, int price,
+                                   LocalDateTime date, int count, OrderListOrderItemResponse orderItem,
+                                   OrderListPaymentResponse payment, String merchantUid, OrderListDeliveryResponse delivery) {
         this.id = id;
         this.status = status;
         this.price = price;
@@ -30,5 +33,6 @@ public class OrderListOrdersResponse {
         this.orderItem = orderItem;
         this.payment = payment;
         this.merchantUid = merchantUid;
+        this.delivery = delivery;
     }
 }

--- a/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
+++ b/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
@@ -9,4 +9,5 @@ public class SafeKingPaymentConst {
     public static final String IAMPORT_PAYMENT_ERROR = "아임포트 에러 발생";
     public static final String PAYMENT_REQUEST_CANCEL = "결제 인증 취소요청";
     public static final String PAYMENT_REQUEST_CANCEL_FAIL = "결제 인증 취소요청 실패";
+    public static final String REFUND_FEE_CHECK = "반품비가 결제금액 보다 큽니다.";
 }

--- a/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
+++ b/src/main/java/com/safeking/shop/domain/payment/constant/SafeKingPaymentConst.java
@@ -2,7 +2,8 @@ package com.safeking.shop.domain.payment.constant;
 
 public class SafeKingPaymentConst {
     public static final String PAYMENT_PAID_SUCCESS = "결제 완료";
-    public static final String PAYMENT_PAID_CANCEL = "결제 취소";
+    public static final String PAYMENT_PAID_FAIL = "결제 성공 실패";
+    public static final String PAYMENT_PAID_CANCEL_SUCCESS = "결제 취소 성공";
     public static final String SAFEKING_PAYMENT_NONE = "DB에 결제 내역이 없습니다. 주문 후에 결제 해주세요.";
     public static final String PAYMENT_AMOUNT_DIFFERENT_WEBHOOK = "가맹점 결제금액과 요청 결제금액이 다릅니다.(웹훅)";
     public static final String PAYMENT_AMOUNT_DIFFERENT_CALLBACK = "가맹점 결제금액과 요청 결제금액이 다릅니다.(콜백)";

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/request/PaymentCancelRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -13,21 +14,24 @@ public class PaymentCancelRequest {
     private String impUid; // 결제 고유 번호
     @NotBlank(message = "주문 번호가 빈 값 입니다.")
     private String merchantUid; //주문 번호
-    private Double amount; // 취소 요청금액(누락시 전액 취소)
-    private Double taxFree; // 취소요청금액 중 면세금액 (누락되면 0원처리)
-    /**
-     * 부가세 지정(기본값: null)
-     * 결제 시 부가세를 지정했던 경우 필수 입력 바랍니다.
-     *
-     * 지원 PG사
-     * -나이스페이먼츠
-     * -이니시스
-     */
-    private Integer vatAmount;
-    private String refundTel; // 환불계좌 예금주 연락처(가상계좌 취소,스마트로 PG사 인경우 필수 )
-    private String checksum; // 현재시점의 취소 가능한 잔액.
+    @NotNull(message = "반품비가 빈 값 입니다.")
+    private Double returnFee; // 반품비
     private String reason; // 취소사유
-    private String refundHolder; // 환불계좌 예금주 (가상계좌 취소시 필수)
-    private String refundBank; // 환불계좌 은행코드 (하단 은행코드표 참조, 가상계좌 취소시 필수)
-    private String refundAccount; // 환불계좌 계좌번호 (가상계좌 취소시 필수)
+
+//    private Double amount; // 취소 요청금액(누락시 전액 취소)
+//    private Double taxFree; // 취소요청금액 중 면세금액 (누락되면 0원처리)
+//    /**
+//     * 부가세 지정(기본값: null)
+//     * 결제 시 부가세를 지정했던 경우 필수 입력 바랍니다.
+//     *
+//     * 지원 PG사
+//     * -나이스페이먼츠
+//     * -이니시스
+//     */
+//    private Integer vatAmount;
+//    private String refundTel; // 환불계좌 예금주 연락처(가상계좌 취소,스마트로 PG사 인경우 필수 )
+//    private String checksum; // 현재시점의 취소 가능한 잔액.
+//    private String refundHolder; // 환불계좌 예금주 (가상계좌 취소시 필수)
+//    private String refundBank; // 환불계좌 은행코드 (하단 은행코드표 참조, 가상계좌 취소시 필수)
+//    private String refundAccount; // 환불계좌 계좌번호 (가상계좌 취소시 필수)
 }

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCancelPaymentResponse.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCancelPaymentResponse.java
@@ -1,0 +1,19 @@
+package com.safeking.shop.domain.payment.web.client.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PaymentCancelPaymentResponse {
+    private Double amount; // 환불 금액
+    private String buyerName; // 주문자명
+
+    @Builder
+    public PaymentCancelPaymentResponse(Double amount, String buyerName) {
+        this.amount = amount;
+        this.buyerName = buyerName;
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCancelResponse.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/dto/response/PaymentCancelResponse.java
@@ -1,0 +1,19 @@
+package com.safeking.shop.domain.payment.web.client.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PaymentCancelResponse {
+    private String message;
+    private PaymentCancelPaymentResponse payment;
+
+    @Builder
+    public PaymentCancelResponse(String message, PaymentCancelPaymentResponse payment) {
+        this.message = message;
+        this.payment = payment;
+    }
+}

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportService.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportService.java
@@ -4,6 +4,7 @@ import com.safeking.shop.domain.payment.domain.entity.SafekingPayment;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentAuthCancelRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentCallbackRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentWebhookRequest;
+import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCancelResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCallbackResponse;
 import com.siot.IamportRestClient.response.IamportResponse;
@@ -15,6 +16,6 @@ public interface IamportService {
     // 결제
     PaymentResponse<PaymentCallbackResponse> paymentByCallback(PaymentCallbackRequest request);
     void paymentByWebhook(PaymentWebhookRequest request);
-    IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment);
+    PaymentCancelResponse cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment);
     SafekingPayment getSafekingPayment(String merchantUid);
 }

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportService.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportService.java
@@ -15,6 +15,6 @@ public interface IamportService {
     // 결제
     PaymentResponse<PaymentCallbackResponse> paymentByCallback(PaymentCallbackRequest request);
     void paymentByWebhook(PaymentWebhookRequest request);
-    IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, SafekingPayment findSafekingPayment);
+    IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment);
     SafekingPayment getSafekingPayment(String merchantUid);
 }

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
@@ -94,7 +94,7 @@ public class IamportServiceImpl implements IamportService {
             // 결제 금액 비교(결제 금액이 다르다면)
             if(findSafekingPayment.getAmount() != response.getAmount().intValue()) {
                 // 결제, 주문 취소 로직
-                cancel(request.getImpUid(), response.getMerchantUid(), PAYMENT_AMOUNT_DIFFERENT_CALLBACK, findSafekingPayment);
+                cancel(request.getImpUid(), response.getMerchantUid(), PAYMENT_AMOUNT_DIFFERENT_CALLBACK, 0d, findSafekingPayment);
                 log.debug("[결제검증 위조] {}", PAYMENT_AMOUNT_DIFFERENT_CALLBACK);
 
                 // 응답 생성
@@ -200,7 +200,7 @@ public class IamportServiceImpl implements IamportService {
     public IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment) {
         try {
             // 결제 취소
-            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, findSafekingPayment);
+            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, cancelReason, findSafekingPayment);
 
             // 주문 취소
             Order findOrder = iamportServiceSubMethod.cancelOrder(merchantUid, cancelReason);

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
@@ -165,7 +165,7 @@ public class IamportServiceImpl implements IamportService {
             // 결제 금액 비교(결제 금액이 다르다면)
             if(findSafekingPayment.getAmount() != response.getAmount().intValue()) {
                 // 결제, 주문 취소 로직
-                cancel(request.getImpUid(), response.getMerchantUid(), response.getCancelReason(), findSafekingPayment);
+                cancel(request.getImpUid(), response.getMerchantUid(), response.getCancelReason(), 0d, findSafekingPayment);
 
                 log.debug("[결제검증 위조] {}", PAYMENT_AMOUNT_DIFFERENT_WEBHOOK);
                 return;
@@ -197,10 +197,10 @@ public class IamportServiceImpl implements IamportService {
      */
     @Transactional
     @Override
-    public IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, SafekingPayment findSafekingPayment) {
+    public IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment) {
         try {
             // 결제 취소
-            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, findSafekingPayment);
+            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, findSafekingPayment);
 
             // 주문 취소
             Order findOrder = iamportServiceSubMethod.cancelOrder(merchantUid, cancelReason);

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
@@ -13,6 +13,8 @@ import com.safeking.shop.domain.payment.domain.repository.SafekingPaymentReposit
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentAuthCancelRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentCallbackRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentWebhookRequest;
+import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCancelPaymentResponse;
+import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCancelResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCallbackResponse;
 import com.siot.IamportRestClient.IamportClient;
@@ -78,7 +80,7 @@ public class IamportServiceImpl implements IamportService {
                     .errorMsg(request.getErrorMsg())
                     .build();
 
-            return new PaymentResponse<>(PAYMENT_PAID_CANCEL, paymentCallbackResponse);
+            return new PaymentResponse<>(PAYMENT_PAID_FAIL, paymentCallbackResponse);
         }
 
         PaymentCallbackResponse paymentCallbackResponse = null;
@@ -197,7 +199,7 @@ public class IamportServiceImpl implements IamportService {
      */
     @Transactional
     @Override
-    public IamportResponse<Payment> cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment) {
+    public PaymentCancelResponse cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment) {
         try {
             // 결제 취소
             IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, cancelReason, findSafekingPayment);
@@ -206,7 +208,7 @@ public class IamportServiceImpl implements IamportService {
             Order findOrder = iamportServiceSubMethod.cancelOrder(merchantUid, cancelReason);
             findOrder.changeSafekingPayment(findSafekingPayment); // 연관관계 적용
 
-            return cancelPaymentResponse;
+            return getPaymentCancelResponse(cancelPaymentResponse, findSafekingPayment.getBuyerName());
 
         } catch (IamportResponseException e) {
             log.error("[IamportResponseException] {}", e.getMessage());
@@ -215,6 +217,18 @@ public class IamportServiceImpl implements IamportService {
             log.error("[IOException] {}", e.getMessage());
             throw new PaymentException(e.getMessage());
         }
+    }
+
+    private PaymentCancelResponse getPaymentCancelResponse(IamportResponse<Payment> cancelPaymentResponse, String buyerName) {
+        PaymentCancelPaymentResponse payment = PaymentCancelPaymentResponse.builder()
+                .amount(cancelPaymentResponse.getResponse().getCancelAmount().doubleValue())
+                .buyerName(buyerName)
+                .build();
+
+        return PaymentCancelResponse.builder()
+                .message(PAYMENT_PAID_CANCEL_SUCCESS)
+                .payment(payment)
+                .build();
     }
 
     /**

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
@@ -42,7 +42,7 @@ public class IamportServiceSubMethod {
      * 결제 취소
      */
     @NotNull
-    public IamportResponse<Payment> cancelPayment(String impUid, Double returnFee, SafekingPayment findSafekingPayment) throws IamportResponseException, IOException {
+    public IamportResponse<Payment> cancelPayment(String impUid, Double returnFee, String cancelReason, SafekingPayment findSafekingPayment) throws IamportResponseException, IOException {
 
         double paid = findSafekingPayment.getAmount().doubleValue(); // 결제금액
         Double refundFee = paid - returnFee; // 환불 금액 = 결제금액 - 반품비용
@@ -53,7 +53,7 @@ public class IamportServiceSubMethod {
         }
 
         CancelData cancelData = new CancelData(impUid, true, new BigDecimal(returnFee));
-        cancelData.setReason(findSafekingPayment.getCancelReason());
+        cancelData.setReason(cancelReason);
         IamportResponse<Payment> cancelPaymentResponse = client.cancelPaymentByImpUid(cancelData); //imp_uid를 통한 전액취소
         findSafekingPayment.changeSafekingPayment(CANCEL, cancelPaymentResponse.getResponse()); // 결제 취소 내용으로 갱신
 

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
@@ -17,6 +17,7 @@ import com.siot.IamportRestClient.response.Payment;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -30,6 +31,7 @@ import static com.safeking.shop.domain.payment.domain.entity.PaymentStatus.CANCE
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class IamportServiceSubMethod {
 
     private final IamportClient client;

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceSubMethod.java
@@ -19,10 +19,12 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static com.safeking.shop.domain.order.constant.OrderConst.ORDER_NONE;
+import static com.safeking.shop.domain.payment.constant.SafeKingPaymentConst.REFUND_FEE_CHECK;
 import static com.safeking.shop.domain.payment.constant.SafeKingPaymentConst.SAFEKING_PAYMENT_NONE;
 import static com.safeking.shop.domain.payment.domain.entity.PaymentStatus.CANCEL;
 
@@ -40,8 +42,18 @@ public class IamportServiceSubMethod {
      * 결제 취소
      */
     @NotNull
-    public IamportResponse<Payment> cancelPayment(String impUid, SafekingPayment findSafekingPayment) throws IamportResponseException, IOException {
-        CancelData cancelData = new CancelData(impUid, true);
+    public IamportResponse<Payment> cancelPayment(String impUid, Double returnFee, SafekingPayment findSafekingPayment) throws IamportResponseException, IOException {
+
+        double paid = findSafekingPayment.getAmount().doubleValue(); // 결제금액
+        Double refundFee = paid - returnFee; // 환불 금액 = 결제금액 - 반품비용
+
+        // 환불금액이 음수인 경우
+        if(refundFee < 0) {
+            throw new PaymentException(REFUND_FEE_CHECK);
+        }
+
+        CancelData cancelData = new CancelData(impUid, true, new BigDecimal(returnFee));
+        cancelData.setReason(findSafekingPayment.getCancelReason());
         IamportResponse<Payment> cancelPaymentResponse = client.cancelPaymentByImpUid(cancelData); //imp_uid를 통한 전액취소
         findSafekingPayment.changeSafekingPayment(CANCEL, cancelPaymentResponse.getResponse()); // 결제 취소 내용으로 갱신
 

--- a/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
@@ -6,6 +6,7 @@ import com.safeking.shop.domain.payment.web.client.dto.request.PaymentAuthCancel
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentCallbackRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentCancelRequest;
 import com.safeking.shop.domain.payment.web.client.dto.request.PaymentWebhookRequest;
+import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCancelResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentResponse;
 import com.safeking.shop.domain.payment.web.client.dto.response.PaymentCallbackResponse;
 import com.safeking.shop.domain.payment.web.client.service.IamportService;
@@ -71,13 +72,13 @@ public class PaymentController {
      * 결제 취소
      */
     @PostMapping("/payment/cancel")
-    public ResponseEntity<IamportResponse<Payment>> cancelPayment(@Valid @RequestBody PaymentCancelRequest paymentCancelRequest, HttpServletRequest request) {
+    public ResponseEntity<PaymentCancelResponse> cancelPayment(@Valid @RequestBody PaymentCancelRequest paymentCancelRequest, HttpServletRequest request) {
 
         // 회원 검증
         validationOrderService.validationMember(request.getHeader(AUTH_HEADER));
 
         // 결제 취소
-        IamportResponse<Payment> response = iamportService.cancel(
+        PaymentCancelResponse response = iamportService.cancel(
                 paymentCancelRequest.getImpUid(),
                 paymentCancelRequest.getMerchantUid(),
                 paymentCancelRequest.getReason(),

--- a/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/controller/PaymentController.java
@@ -81,6 +81,7 @@ public class PaymentController {
                 paymentCancelRequest.getImpUid(),
                 paymentCancelRequest.getMerchantUid(),
                 paymentCancelRequest.getReason(),
+                paymentCancelRequest.getReturnFee(),
                 iamportService.getSafekingPayment(paymentCancelRequest.getMerchantUid())
         );
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: seaung
+    active: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: dev
+    active: seaung

--- a/src/main/resources/templates/payment.html
+++ b/src/main/resources/templates/payment.html
@@ -21,7 +21,7 @@
                 pg : 'html5_inicis.INIpayTest',
                 pay_method : 'card',
                 // merchant_uid: "IMP"+makeMerchantUid,
-                merchant_uid: "15",
+                merchant_uid: "SFK-230206201244-90e4c7d8",
                 name : '안전모 결제 테스트',
                 amount : 2800,
                 buyer_email : 'safeKing@chai.finance',


### PR DESCRIPTION
# 23/02/06 데모 반영
## 결제
 * 결제 취소(환불) 로직 수정
	 * 반품비를 제외하고 결제 취소(환불) 처리
 * 결제 취소 API에 반품비(`return_fee`) request 추가
## 주문
* 관리자 주문 상세 수정
	* `thumbnail`, `payment` 추가
* 주문 다건 조회 수정
	* `payment` 추가