### PR TITLE
주문, 결제 API 수정

### DIFF
--- a/src/main/java/com/safeking/shop/domain/order/constant/OrderConst.java
+++ b/src/main/java/com/safeking/shop/domain/order/constant/OrderConst.java
@@ -8,7 +8,8 @@ public class OrderConst {
     public static final String ORDER_SUCCESS = "주문 성공";
     public static final String ORDER_FAIL = "주문 실패";
     public static final String ORDER_NONE = "주문이 없습니다.";
-    public static final String ORDER_CANCEL_DELIVERY_DONE = "배송중이거나 배송완료된 상품은 취소가 불가합니다.";
+    public static final String ORDER_CANCEL_IN_DELIVERY = "배송중인 상품은 취소가 불가합니다.";
+    public static final String ORDER_CANCEL_DELIVERY_DONE = "배송완료된 상품은 취소가 불가합니다.";
     public static final String ORDER_MODIFY_DELIVERY_DONE = "배송 중이거나 배송완료된 상품은 주문(배송) 정보 수정이 불가합니다.";
     public static final String ORDER_CANCEL_SUCCESS = "주문 취소 성공";
     public static final String ORDER_CANCEL_FAIL = "주문 취소 실패";
@@ -23,6 +24,8 @@ public class OrderConst {
     public static final String ORDER_LIST_FIND_FAIL_PAYMENT_STATUS = "결제 상태가 올바르지 않습니다.";
     public static final String ORDER_LIST_FIND_FAIL_DELIVERY_STATUS = "배송 상태가 올바르지 않습니다.";
     public static final String ORDER_LIST_FIND_FAIL_ORDER_STATUS = "주문 상태가 올바르지 않습니다.";
+    public static final String ORDER_LIST_FIND_FAIL_ORDER_STATUS_IS_CANCEL = "주문이 취소된 항목은 조회할수 없습니다.";
+    public static final String ORDER_LIST_FIND_FAIL_PAYMENT_STATUS_IS_CANCEL = "결제가 취소된 항목은 조회할수 없습니다.";
 
 
     /* 관리자 */

--- a/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/safeking/shop/domain/order/domain/entity/Order.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.safeking.shop.domain.order.constant.OrderConst.ORDER_CANCEL_IN_DELIVERY;
+
 @Entity @Getter
 @Table(name = "orders", uniqueConstraints = {
         @UniqueConstraint(name = "merchant_uid_unique", columnNames = {"merchantUid"})
@@ -94,6 +96,10 @@ public class Order extends BaseTimeEntity {
         // 배송중이면 주문취소 불가
         if(delivery.getStatus().equals(DeliveryStatus.IN_DELIVERY)) {
             throw new OrderException(OrderConst.ORDER_CANCEL_DELIVERY_DONE);
+        }
+        // 배송 완료면 주문취소 불가 (현재 반품 비지니스가 없어서 배송완료되면 환불 불가함)
+        else if(delivery.getStatus().equals(DeliveryStatus.COMPLETE)) {
+            throw new OrderException(OrderConst.ORDER_CANCEL_IN_DELIVERY);
         }
 
         this.status = OrderStatus.CANCEL;

--- a/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
+++ b/src/main/java/com/safeking/shop/domain/order/web/controller/OrderController.java
@@ -138,7 +138,7 @@ public class OrderController {
     }
 
     /**
-     * 주문 다건 조회
+     * 주문 목록 조회
      */
     @GetMapping("/order/list")
     public ResponseEntity<OrderListResponse> searchOrderList(OrderSearchCondition condition, Pageable pageable, HttpServletRequest request) {

--- a/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
+++ b/src/main/java/com/safeking/shop/domain/payment/web/client/service/IamportServiceImpl.java
@@ -202,15 +202,16 @@ public class IamportServiceImpl implements IamportService {
     @Override
     public PaymentCancelResponse cancel(String impUid, String merchantUid, String cancelReason, Double returnFee, SafekingPayment findSafekingPayment) {
         try {
-            // 결제 취소
-            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, cancelReason, findSafekingPayment);
-
             // 주문 취소
             Order findOrder = iamportServiceSubMethod.cancelOrder(merchantUid, cancelReason);
-            findOrder.changeSafekingPayment(findSafekingPayment); // 연관관계 적용
 
             // 배송 취소
             Delivery findDelivery = iamportServiceSubMethod.cancelDelivery(findOrder.getDelivery().getId());
+
+            // 결제 취소
+            IamportResponse<Payment> cancelPaymentResponse = iamportServiceSubMethod.cancelPayment(impUid, returnFee, cancelReason, findSafekingPayment);
+
+            findOrder.changeSafekingPayment(findSafekingPayment); // 연관관계 적용
             findOrder.changeDelivery(findDelivery); // 연관관계 적용
 
             return getPaymentCancelResponse(cancelPaymentResponse, findSafekingPayment.getBuyerName());


### PR DESCRIPTION
# 결제
* 결제 취소 로직 수정
   * 배송완료 상태일때 결제취소(환불) 불가
   * 현재 반품 비지니스가 없기 때문
# 주문
* 주문 목록 조회 수정
   * 주문취소, 결제취소인 항목 조회 불가
   * 환불 내역 API가 존재하기 때문